### PR TITLE
어미 곰, 호수의 여인, 모르간 르 페이, 베히모스 카드 구현

### DIFF
--- a/Assets/Prefabs/Game/Cards/Norse/Soul_MotherBear.prefab
+++ b/Assets/Prefabs/Game/Cards/Norse/Soul_MotherBear.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &8052767433709974904
+--- !u!1001 &6259767085455889839
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -50,84 +50,59 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: m_Name
-      value: Soul_Poseidon
+      value: Soul_MotherBear
       objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: AD
-      value: 55
+    - target: {fileID: 7012978402852111762, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_SpriteTilingProperty.oldSize.y
+      value: 3.4570312
       objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: HP
-      value: 55
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: cost
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: cardName
-      value: Poseidon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: description
-      value: 'Advent: deal 25 damage to all enemies'
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: illustration
+    - target: {fileID: 7249511656965813670, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: cb8a0f9f049edde48a875ba0bcc43995, type: 3}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: EffectOnCardUsed
-      value: 
-      objectReference: {fileID: 391618131688367025}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: pieceRestriction
-      value: 8
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 21300000, guid: 1f09f2d65507b3e44b9876074a696b38, type: 3}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      insertIndex: 6
-      addedObject: {fileID: 1292469394887977406}
+      insertIndex: -1
+      addedObject: {fileID: 3604200065000529882}
   m_SourcePrefab: {fileID: 100100000, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
---- !u!114 &391618131688367025 stripped
+--- !u!114 &4355344996031333222 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 8052767433709974904}
+  m_PrefabInstance: {fileID: 6259767085455889839}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8071162094226948297}
+  m_GameObject: {fileID: 5268229176265334814}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &8071162094226948297 stripped
+--- !u!1 &5268229176265334814 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 8052767433709974904}
+  m_PrefabInstance: {fileID: 6259767085455889839}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1292469394887977406
+--- !u!114 &3604200065000529882
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8071162094226948297}
+  m_GameObject: {fileID: 5268229176265334814}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 596391799992f8646846d8c078579754, type: 3}
+  m_Script: {fileID: 11500000, guid: a3f53e91dfcc02143bb0c858e94a8b85, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardName: "\uD3EC\uC138\uC774\uB3C8"
-  cost: 7
-  illustration: {fileID: 21300000, guid: cb8a0f9f049edde48a875ba0bcc43995, type: 3}
-  description: "\uAE30\uBB3C: \uB8E9\n\uBC30\uCE58:\n\uBAA8\uB4E0 \uAE30\uBB3C\uC5D0\uAC8C
-    25\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4.\n"
-  EffectOnCardUsed: {fileID: 391618131688367025}
-  pieceRestriction: 8
-  AD: 55
-  HP: 55
+  cardName: "\uC5B4\uBBF8 \uACF0"
+  cost: 4
+  illustration: {fileID: 0}
+  description: "\uAE30\uBB3C: \uB8E9/\uD3F0"
+  EffectOnCardUsed: {fileID: 4355344996031333222}
+  pieceRestriction: 9
+  AD: 35
+  HP: 50
   InfusedPiece: {fileID: 0}

--- a/Assets/Prefabs/Game/Cards/Norse/Soul_MotherBear.prefab.meta
+++ b/Assets/Prefabs/Game/Cards/Norse/Soul_MotherBear.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 69c628af0606ded408e60e35428eab89
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/Cards/Soul_Behemoth.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_Behemoth.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &8052767433709974904
+--- !u!1001 &2416270540618328052
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -50,39 +50,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: m_Name
-      value: Soul_Poseidon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: AD
-      value: 55
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: HP
-      value: 55
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: cost
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: cardName
-      value: Poseidon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: description
-      value: 'Advent: deal 25 damage to all enemies'
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: illustration
-      value: 
-      objectReference: {fileID: 21300000, guid: cb8a0f9f049edde48a875ba0bcc43995, type: 3}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: EffectOnCardUsed
-      value: 
-      objectReference: {fileID: 391618131688367025}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: pieceRestriction
-      value: 8
+      value: Soul_Behemoth
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
@@ -90,44 +58,44 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      insertIndex: 6
-      addedObject: {fileID: 1292469394887977406}
+      insertIndex: -1
+      addedObject: {fileID: 6592858290932310892}
   m_SourcePrefab: {fileID: 100100000, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
---- !u!114 &391618131688367025 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 8052767433709974904}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8071162094226948297}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &8071162094226948297 stripped
+--- !u!1 &4488957673976943173 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 8052767433709974904}
+  m_PrefabInstance: {fileID: 2416270540618328052}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1292469394887977406
+--- !u!114 &6592858290932310892
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8071162094226948297}
+  m_GameObject: {fileID: 4488957673976943173}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 596391799992f8646846d8c078579754, type: 3}
+  m_Script: {fileID: 11500000, guid: 4236771400fe8d842af19c379876c008, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardName: "\uD3EC\uC138\uC774\uB3C8"
-  cost: 7
-  illustration: {fileID: 21300000, guid: cb8a0f9f049edde48a875ba0bcc43995, type: 3}
-  description: "\uAE30\uBB3C: \uB8E9\n\uBC30\uCE58:\n\uBAA8\uB4E0 \uAE30\uBB3C\uC5D0\uAC8C
-    25\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4.\n"
-  EffectOnCardUsed: {fileID: 391618131688367025}
+  cardName: "\uBCA0\uD5E4\uBAA8\uC2A4"
+  cost: 9
+  illustration: {fileID: 0}
+  description: "\uAE30\uBB3C: \uB8E9\n\uB0B4 \uD134\uC774 \uB05D\uB0A0 \uB54C, +10/+10\uC744
+    \uC5BB\uC2B5\uB2C8\uB2E4."
+  EffectOnCardUsed: {fileID: 5415071180265959741}
   pieceRestriction: 8
-  AD: 55
-  HP: 55
+  AD: 70
+  HP: 70
   InfusedPiece: {fileID: 0}
+--- !u!114 &5415071180265959741 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+  m_PrefabInstance: {fileID: 2416270540618328052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4488957673976943173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Game/Cards/Soul_Behemoth.prefab.meta
+++ b/Assets/Prefabs/Game/Cards/Soul_Behemoth.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad9ea7076351dda45bceebe2ed5d9deb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/Cards/Soul_LadyOfTheLake.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_LadyOfTheLake.prefab
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6802077257807117280
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3734480829488543473, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4488957673976943173, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      propertyPath: m_Name
+      value: Soul_LadyOfTheLake
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 6592858290932310892, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4488957673976943173, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -542098215232420279}
+  m_SourcePrefab: {fileID: 100100000, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+--- !u!114 &1532323068371667677 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5415071180265959741, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+  m_PrefabInstance: {fileID: 6802077257807117280}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6930527465101322661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6930527465101322661 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4488957673976943173, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+  m_PrefabInstance: {fileID: 6802077257807117280}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &-542098215232420279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6930527465101322661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76e7722b1955d184d9553bbb59f9253c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cardName: "\uD638\uC218\uC758 \uC5EC\uC778"
+  cost: 6
+  illustration: {fileID: 0}
+  description: "\uAE30\uBB3C: \uD038/\uBE44\uC20D\n\uB0B4 \uD134\uC774 \uB05D\uB0A0
+    \uB54C \uBB34\uC791\uC704 \uC544\uAD70 \uAE30\uBB3C\uC5D0\uAC8C +20/+20\uC744
+    \uBD80\uC5EC\uD569\uB2C8\uB2E4"
+  EffectOnCardUsed: {fileID: 1532323068371667677}
+  pieceRestriction: 20
+  AD: 40
+  HP: 40
+  InfusedPiece: {fileID: 0}

--- a/Assets/Prefabs/Game/Cards/Soul_LadyOfTheLake.prefab.meta
+++ b/Assets/Prefabs/Game/Cards/Soul_LadyOfTheLake.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a624a3c6dfec07e4e96e01a10fa19a1d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/Cards/Soul_MorganLeFay.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_MorganLeFay.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &8052767433709974904
+--- !u!1001 &2293662741994202411
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -50,39 +50,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: m_Name
-      value: Soul_Poseidon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: AD
-      value: 55
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: HP
-      value: 55
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: cost
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: cardName
-      value: Poseidon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: description
-      value: 'Advent: deal 25 damage to all enemies'
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: illustration
-      value: 
-      objectReference: {fileID: 21300000, guid: cb8a0f9f049edde48a875ba0bcc43995, type: 3}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: EffectOnCardUsed
-      value: 
-      objectReference: {fileID: 391618131688367025}
-    - target: {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: pieceRestriction
-      value: 8
+      value: Soul_MorganLeFay
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
@@ -90,44 +58,45 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      insertIndex: 6
-      addedObject: {fileID: 1292469394887977406}
+      insertIndex: -1
+      addedObject: {fileID: -8018143768630719333}
   m_SourcePrefab: {fileID: 100100000, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
---- !u!114 &391618131688367025 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 8052767433709974904}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8071162094226948297}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &8071162094226948297 stripped
+--- !u!1 &6491951197048986 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 8052767433709974904}
+  m_PrefabInstance: {fileID: 2293662741994202411}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1292469394887977406
+--- !u!114 &-8018143768630719333
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8071162094226948297}
+  m_GameObject: {fileID: 6491951197048986}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 596391799992f8646846d8c078579754, type: 3}
+  m_Script: {fileID: 11500000, guid: e71d14047dc54d84aad316ac74428df9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardName: "\uD3EC\uC138\uC774\uB3C8"
-  cost: 7
-  illustration: {fileID: 21300000, guid: cb8a0f9f049edde48a875ba0bcc43995, type: 3}
-  description: "\uAE30\uBB3C: \uB8E9\n\uBC30\uCE58:\n\uBAA8\uB4E0 \uAE30\uBB3C\uC5D0\uAC8C
-    25\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4.\n"
-  EffectOnCardUsed: {fileID: 391618131688367025}
-  pieceRestriction: 8
-  AD: 55
-  HP: 55
+  cardName: "\uBAA8\uB974\uAC74 \uB974 \uD398\uC774"
+  cost: 4
+  illustration: {fileID: 0}
+  description: "\uAE30\uBB3C: \uD038/\uBE44\uC20D\n\uB0B4 \uD134\uC774 \uB05D\uB0A0
+    \uB54C, \uBB34\uC791\uC704 \uC544\uAD70 \uAE30\uBB3C\uC758 \uCCB4\uB825\uC744
+    \uBAA8\uB450 \uD68C\uBCF5\uC2DC\uD0B5\uB2C8\uB2E4."
+  EffectOnCardUsed: {fileID: 8465317945174799330}
+  pieceRestriction: 20
+  AD: 20
+  HP: 30
   InfusedPiece: {fileID: 0}
+--- !u!114 &8465317945174799330 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+  m_PrefabInstance: {fileID: 2293662741994202411}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6491951197048986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Game/Cards/Soul_MorganLeFay.prefab.meta
+++ b/Assets/Prefabs/Game/Cards/Soul_MorganLeFay.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d7ad69c35265ccd4ea5664162fca2c34
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TestScenes/GameScene_PJH.unity
+++ b/Assets/Scenes/TestScenes/GameScene_PJH.unity
@@ -1560,11 +1560,15 @@ MonoBehaviour:
       soulEssence: 0
       deck: []
       hand: []
+      spellDamageIncrease: 0
+      spellDamageCoefficient: 1
     playerBlack:
       soulOrbs: 0
       soulEssence: 0
       deck: []
       hand: []
+      spellDamageIncrease: 0
+      spellDamageCoefficient: 1
   bottomPlayerColor: 0
   chessBoard: {fileID: 1628251987148721090}
   cardBoard: {fileID: 1951553768}
@@ -2315,6 +2319,10 @@ MonoBehaviour:
   hand:
   - {fileID: 90797455826848939, guid: fc33ddca6bc40df4db6a584de32b9753, type: 3}
   - {fileID: 1292469394887977406, guid: 69acd9f53abcc974da0de5adf88dba59, type: 3}
+  - {fileID: 3604200065000529882, guid: 69c628af0606ded408e60e35428eab89, type: 3}
+  - {fileID: 6592858290932310892, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
+  - {fileID: -542098215232420279, guid: a624a3c6dfec07e4e96e01a10fa19a1d, type: 3}
+  - {fileID: -8018143768630719333, guid: d7ad69c35265ccd4ea5664162fca2c34, type: 3}
 --- !u!4 &1707751552
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Game/Card/Cards/Behemoth.cs
+++ b/Assets/Script/Game/Card/Cards/Behemoth.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Behemoth : SoulCard
+{
+    protected override void Awake()
+    {
+        base.Awake();
+        gameObject.GetComponent<SoulCard>().OnInfuse += SoulEffect;
+    }
+
+    public void SoulEffect(ChessPiece chessPiece)
+    {
+        GameManager.instance.whiteController.OnMyTurnEnd += () => SoulEffect2(InfusedPiece);
+    }
+
+    public void SoulEffect2(ChessPiece piece)
+    {
+        piece.maxHP += 10;
+        piece.AD += 10;
+        piece.soul.HP += 10;
+        piece.soul.AD += 10;
+    }
+}

--- a/Assets/Script/Game/Card/Cards/Behemoth.cs.meta
+++ b/Assets/Script/Game/Card/Cards/Behemoth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4236771400fe8d842af19c379876c008
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/Card/Cards/LadyOfTheLake.cs
+++ b/Assets/Script/Game/Card/Cards/LadyOfTheLake.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LadyOfTheLake : SoulCard
+{
+    protected override void Awake()
+    {
+        base.Awake();
+        gameObject.GetComponent<SoulCard>().OnInfuse += SoulEffect;
+    }
+
+    public void SoulEffect(ChessPiece chessPiece)
+    {
+        //강림 시 OnMyTurnEnd에 함수 추가
+        GameManager.instance.whiteController.OnMyTurnEnd += () => SoulEffect2(InfusedPiece);
+    }
+
+    public void SoulEffect2(ChessPiece piece) //턴 종료 시마다 호출될 텐데
+    {
+        List<ChessPiece> pieceList = new List<ChessPiece>();
+        for (int i = GameManager.instance.gameData.pieceObjects.Count - 1; i >= 0; i--)
+        {
+            if (GameManager.instance.gameData.pieceObjects[i].pieceColor == piece.pieceColor)
+                pieceList.Add(GameManager.instance.gameData.pieceObjects[i]);
+        }
+
+        int temp = Random.Range(0, pieceList.Count);
+        pieceList[temp].maxHP += 20;
+        pieceList[temp].AD += 20;
+    }
+}

--- a/Assets/Script/Game/Card/Cards/LadyOfTheLake.cs.meta
+++ b/Assets/Script/Game/Card/Cards/LadyOfTheLake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76e7722b1955d184d9553bbb59f9253c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/Card/Cards/MorganLeFay.cs
+++ b/Assets/Script/Game/Card/Cards/MorganLeFay.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MorganLeFay : SoulCard
+{
+    protected override void Awake()
+    {
+        base.Awake();
+        gameObject.GetComponent<SoulCard>().OnInfuse += SoulEffect;
+    }
+
+    public void SoulEffect(ChessPiece chessPiece)
+    {
+        //강림 시 OnMyTurnEnd에 함수 추가
+        GameManager.instance.whiteController.OnMyTurnEnd += () => SoulEffect2(InfusedPiece);
+    }
+
+    public void SoulEffect2(ChessPiece piece) //턴 종료 시마다 호출되는 함수인데
+    {
+        List<ChessPiece> pieceList = new List<ChessPiece>();
+        for (int i = GameManager.instance.gameData.pieceObjects.Count - 1; i >= 0; i--)
+        {
+            if (GameManager.instance.gameData.pieceObjects[i].pieceColor == piece.pieceColor)
+            {
+                //체력이 깎여있는 아군만 pieceList에 추가해서 그 중에서 무작위 회복
+                if (GameManager.instance.gameData.pieceObjects[i].HP != GameManager.instance.gameData.pieceObjects[i].maxHP)
+                    pieceList.Add(GameManager.instance.gameData.pieceObjects[i]);
+            }
+        }
+        if (pieceList.Count > 0)
+        {
+            int temp = Random.Range(0, pieceList.Count);
+            pieceList[temp].HP = pieceList[temp].maxHP;
+        }
+    }
+}

--- a/Assets/Script/Game/Card/Cards/MorganLeFay.cs.meta
+++ b/Assets/Script/Game/Card/Cards/MorganLeFay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e71d14047dc54d84aad316ac74428df9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/Card/Cards/MotherBear.cs
+++ b/Assets/Script/Game/Card/Cards/MotherBear.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MotherBear : SoulCard
+{
+    
+}

--- a/Assets/Script/Game/Card/Cards/MotherBear.cs.meta
+++ b/Assets/Script/Game/Card/Cards/MotherBear.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3f53e91dfcc02143bb0c858e94a8b85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- 어미 곰 카드 프리팹, 스크립트 구현
- 호수의 여인 카드 프리팹, 스크립트 구현
- 모르간 르 페이 카드 프리팹, 스크립트 구현
- 베히모스 카드 프리팹, 스크립트 구현
- 포세이돈 카드 설명 한글로 변경

*RemoveSoul에 이벤트 추가되면 턴 종료 액션에서 카드 기능 함수 제거 필요
*ChessPiece에서 soul에 카드 복제 후 넣는 방식으로 롤백해도 잘 작동합니다