### PR TITLE
아벨 / 크라켄 / 돈키호테 카드 구현

### DIFF
--- a/Assets/Prefabs/Game/Cards/Norse/Spell_Execution.prefab
+++ b/Assets/Prefabs/Game/Cards/Norse/Spell_Execution.prefab
@@ -58,8 +58,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8480252315183081039, guid: 9a701fc1c8dbfa443a6eedf0390be8dd, type: 3}
       propertyPath: description
-      value: Choose one piece and 30 damage to it. If target's health is 60 or below,
-        give 60 damage instead.
+      value: "\uAE30\uBB3C\uC5D0\uAC8C \uD53C\uD574\uB97C 30\uC90D\uB2C8\uB2E4. \uAE30\uBB3C\uC758
+        \uCCB4\uB825\uC774 60\uC774\uD558\uBA74, 60\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
       objectReference: {fileID: 0}
     - target: {fileID: 8480252315183081039, guid: 9a701fc1c8dbfa443a6eedf0390be8dd, type: 3}
       propertyPath: illustration

--- a/Assets/Prefabs/Game/Cards/Soul_Abel.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_Abel.prefab
@@ -52,30 +52,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Soul_Abel
       objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].isFriendly
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].isOpponent
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[1].isFriendly
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].targetPieceType
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[1].targetPieceType
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
     m_RemovedGameObjects: []
@@ -121,6 +97,6 @@ MonoBehaviour:
     \uCC98\uCE58\uD569\uB2C8\uB2E4. "
   EffectOnCardUsed: {fileID: 1942988319355413372}
   pieceRestriction: 4
-  AD: 0
-  HP: 0
+  AD: 30
+  HP: 50
   InfusedPiece: {fileID: 0}

--- a/Assets/Prefabs/Game/Cards/Soul_Abel.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_Abel.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &6200641261614424647
+--- !u!1001 &8095363646312904117
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -50,15 +50,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: m_Name
-      value: Soul_DonQuixote
+      value: Soul_Abel
       objectReference: {fileID: 0}
     - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].isOpponent
+      propertyPath: targetTypes.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: targetTypes.Array.data[0].isFriendly
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: targetTypes.Array.data[0].isOpponent
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: targetTypes.Array.data[1].isFriendly
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: targetTypes.Array.data[0].targetPieceType
-      value: 2
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: targetTypes.Array.data[1].targetPieceType
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
@@ -67,45 +83,44 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7433252666421529211}
+      addedObject: {fileID: -1208510047847783411}
   m_SourcePrefab: {fileID: 100100000, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
---- !u!114 &4369469849057277070 stripped
+--- !u!114 &1942988319355413372 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 6200641261614424647}
+  m_PrefabInstance: {fileID: 8095363646312904117}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5318381834173372406}
+  m_GameObject: {fileID: 8042065685120303108}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5318381834173372406 stripped
+--- !u!1 &8042065685120303108 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 6200641261614424647}
+  m_PrefabInstance: {fileID: 8095363646312904117}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &7433252666421529211
+--- !u!114 &-1208510047847783411
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5318381834173372406}
+  m_GameObject: {fileID: 8042065685120303108}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 06ef52074e405624c8179dc11910aa14, type: 3}
+  m_Script: {fileID: 11500000, guid: a88198c9e05adea4f858bc52fa3d934b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardName: "\uB3C8\uD0A4\uD638\uD14C"
-  cost: 5
-  illustration: {fileID: 21300000, guid: 8df697752e372394a8f47915eb3294fd, type: 3}
-  description: "\uACF5\uACA9\uB825\uC774 100\uC774\uC0C1\uC778 \uAE30\uBB3C\uC744
-    \uACF5\uACA9\uD560 \uB54C 40\uC758 \uCD94\uAC00 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
-  EffectOnCardUsed: {fileID: 4369469849057277070}
-  pieceRestriction: 2
-  AD: 20
-  HP: 60
+  cardName: "\uC544\uBCA8"
+  cost: 4
+  illustration: {fileID: 21300000, guid: 40942faffe6a80d41abffee0807138e3, type: 3}
+  description: "\uC720\uC5B8 : \uC774 \uAE30\uBB3C\uC774 \uACF5\uACA9 \uBC1B\uC544
+    \uCC98\uCE58\uB420 \uB54C, \uC774 \uAE30\uBB3C\uC744 \uACF5\uACA9\uD55C \uAE30\uBB3C\uC744
+    \uCC98\uCE58\uD569\uB2C8\uB2E4. "
+  EffectOnCardUsed: {fileID: 1942988319355413372}
+  pieceRestriction: 4
+  AD: 0
+  HP: 0
   InfusedPiece: {fileID: 0}
-  standardAD: 100
-  extraAD: 40

--- a/Assets/Prefabs/Game/Cards/Soul_Abel.prefab.meta
+++ b/Assets/Prefabs/Game/Cards/Soul_Abel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 97d03e24daf82ae4486ae6ceec8dfdeb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/Cards/Soul_DonQuixote.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_DonQuixote.prefab
@@ -52,14 +52,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Soul_DonQuixote
       objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].isOpponent
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].targetPieceType
-      value: 2
-      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/Game/Cards/Soul_DonQuixote.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_DonQuixote.prefab
@@ -1,0 +1,105 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6200641261614424647
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1322892559162298629, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: m_Name
+      value: Soul_DonQuixote
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: targetTypes.Array.data[0].targetPieceType
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7433252666421529211}
+  m_SourcePrefab: {fileID: 100100000, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+--- !u!114 &4369469849057277070 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+  m_PrefabInstance: {fileID: 6200641261614424647}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5318381834173372406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5318381834173372406 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+  m_PrefabInstance: {fileID: 6200641261614424647}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7433252666421529211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5318381834173372406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06ef52074e405624c8179dc11910aa14, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cardName: "\uB3C8\uD0A4\uD638\uD14C"
+  cost: 5
+  illustration: {fileID: 21300000, guid: 8df697752e372394a8f47915eb3294fd, type: 3}
+  description: "\uACF5\uACA9\uB825\uC774 100\uC774\uC0C1\uC778 \uAE30\uBB3C\uC744
+    \uACF5\uACA9\uD560 \uB54C 40\uC758 \uCD94\uAC00 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
+  EffectOnCardUsed: {fileID: 4369469849057277070}
+  pieceRestriction: 2
+  AD: 20
+  HP: 60
+  InfusedPiece: {fileID: 0}

--- a/Assets/Prefabs/Game/Cards/Soul_DonQuixote.prefab.meta
+++ b/Assets/Prefabs/Game/Cards/Soul_DonQuixote.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc310b2ab5a30de4298b4aea18a015f4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/Cards/Soul_Kraken.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_Kraken.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &6200641261614424647
+--- !u!1001 &1561490478884348676
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -50,7 +50,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: m_Name
-      value: Soul_DonQuixote
+      value: Soul_Kraken
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+      propertyPath: targetTypes.Array.data[0].isFriendly
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: targetTypes.Array.data[0].isOpponent
@@ -58,7 +62,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       propertyPath: targetTypes.Array.data[0].targetPieceType
-      value: 2
+      value: 8
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
@@ -67,45 +71,45 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7433252666421529211}
+      addedObject: {fileID: -7454198298593411323}
   m_SourcePrefab: {fileID: 100100000, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
---- !u!114 &4369469849057277070 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 6200641261614424647}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5318381834173372406}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &5318381834173372406 stripped
+--- !u!1 &749898991636666037 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2288860475118794161, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-  m_PrefabInstance: {fileID: 6200641261614424647}
+  m_PrefabInstance: {fileID: 1561490478884348676}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &7433252666421529211
+--- !u!114 &-7454198298593411323
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5318381834173372406}
+  m_GameObject: {fileID: 749898991636666037}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 06ef52074e405624c8179dc11910aa14, type: 3}
+  m_Script: {fileID: 11500000, guid: d355616cdf7dbf14c9a68b540e67cab1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardName: "\uB3C8\uD0A4\uD638\uD14C"
-  cost: 5
-  illustration: {fileID: 21300000, guid: 8df697752e372394a8f47915eb3294fd, type: 3}
-  description: "\uACF5\uACA9\uB825\uC774 100\uC774\uC0C1\uC778 \uAE30\uBB3C\uC744
-    \uACF5\uACA9\uD560 \uB54C 40\uC758 \uCD94\uAC00 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
-  EffectOnCardUsed: {fileID: 4369469849057277070}
-  pieceRestriction: 2
-  AD: 20
-  HP: 60
+  cardName: "\uD06C\uB77C\uCF04"
+  cost: 8
+  illustration: {fileID: 21300000, guid: e2432675228fa944784b3088686b1838, type: 3}
+  description: "\uC720\uC5B8 : \uBB34\uC791\uC704 \uC801 \uAE30\uBB3C\uC5D0\uAC8C
+    \uD53C\uD574\uB97C 8 \uC90D\uB2C8\uB2E4. 8\uBC88 \uBC18\uBCF5\uD569\uB2C8\uB2E4."
+  EffectOnCardUsed: {fileID: 9152973176935855565}
+  pieceRestriction: 8
+  AD: 78
+  HP: 78
   InfusedPiece: {fileID: 0}
-  standardAD: 100
-  extraAD: 40
+  repeat: 8
+  damage: 8
+--- !u!114 &9152973176935855565 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
+  m_PrefabInstance: {fileID: 1561490478884348676}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 749898991636666037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 706eb39c8a2a18e4fa6b84d7781dee53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Game/Cards/Soul_Kraken.prefab
+++ b/Assets/Prefabs/Game/Cards/Soul_Kraken.prefab
@@ -52,18 +52,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Soul_Kraken
       objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].isFriendly
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].isOpponent
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7687191347765106377, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
-      propertyPath: targetTypes.Array.data[0].targetPieceType
-      value: 8
-      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 4111012812990807176, guid: 83da4afed6fa4804094954017389ffc6, type: 3}
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/Game/Cards/Soul_Kraken.prefab.meta
+++ b/Assets/Prefabs/Game/Cards/Soul_Kraken.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 67b4fae15f5a9a347a47817370ea4705
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TestScenes/LocalTestGameScene.unity
+++ b/Assets/Scenes/TestScenes/LocalTestGameScene.unity
@@ -1560,11 +1560,15 @@ MonoBehaviour:
       soulEssence: 0
       deck: []
       hand: []
+      spellDamageIncrease: 0
+      spellDamageCoefficient: 1
     playerBlack:
       soulOrbs: 0
       soulEssence: 0
       deck: []
       hand: []
+      spellDamageIncrease: 0
+      spellDamageCoefficient: 1
   bottomPlayerColor: 0
   chessBoard: {fileID: 1628251987148721090}
   cardBoard: {fileID: 1951553768}
@@ -2313,9 +2317,7 @@ MonoBehaviour:
   gameBoard: {fileID: 1132824878}
   deck: []
   hand:
-  - {fileID: 90797455826848939, guid: fc33ddca6bc40df4db6a584de32b9753, type: 3}
-  - {fileID: 7999116808895538166, guid: dc7cfa248f3e2994ab4c060628f9ed56, type: 3}
-  - {fileID: 6701591295210432181, guid: 44af0aea009005a43b6d3df9e4c112a1, type: 3}
+  - {fileID: 7433252666421529211, guid: fc310b2ab5a30de4298b4aea18a015f4, type: 3}
   - {fileID: 1292469394887977406, guid: 69acd9f53abcc974da0de5adf88dba59, type: 3}
 --- !u!4 &1707751552
 Transform:

--- a/Assets/Script/Game/Card/Cards/Abel.cs
+++ b/Assets/Script/Game/Card/Cards/Abel.cs
@@ -2,6 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+// TODO 이벤트 시스템 수정 후 재수정
+
 public class Abel : SoulCard
 {
     ChessPiece recent;

--- a/Assets/Script/Game/Card/Cards/Abel.cs
+++ b/Assets/Script/Game/Card/Cards/Abel.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Abel : SoulCard
+{
+    ChessPiece recent;
+    private bool myturn = true;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        gameObject.GetComponent<SoulCard>().OnInfuse += InfuseEffect;
+    }
+
+    public void InfuseEffect(ChessPiece chessPiece)
+    {
+        chessPiece.OnAttacked += OnAttackedEffect;
+        chessPiece.OnKilled += OnkilledEffect;
+        GameManager.instance.whiteController.OnMyDraw += MyTurnSignal;
+        GameManager.instance.whiteController.OnMyTurnEnd += NotMyTurnSignal;
+    }
+
+    public void MyTurnSignal()
+    {
+        myturn = true;
+    }
+
+    public void NotMyTurnSignal()
+    {
+        myturn = false;
+    }
+
+    public void OnAttackedEffect(ChessPiece chessPiece, int damamge)
+    {
+        recent = chessPiece;
+    }
+
+    public void OnkilledEffect(ChessPiece chessPiece)
+    {
+        if (myturn)
+        {
+            recent.Kill();
+        }
+    }
+
+}

--- a/Assets/Script/Game/Card/Cards/Abel.cs.meta
+++ b/Assets/Script/Game/Card/Cards/Abel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a88198c9e05adea4f858bc52fa3d934b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/Card/Cards/DonQuixote.cs
+++ b/Assets/Script/Game/Card/Cards/DonQuixote.cs
@@ -21,7 +21,7 @@ public class DonQuixote : SoulCard
 
     public void StartAttackEffect(ChessPiece chessPiece)
     {
-        if(chessPiece.AD >= standardAD)
+        if (chessPiece.AD >= standardAD)
         {
             this.InfusedPiece.AD += extraAD;
             extraAttack = true;
@@ -30,7 +30,7 @@ public class DonQuixote : SoulCard
 
     public void EndAttackEffect(ChessPiece chessPiece)
     {
-        if(extraAttack)
+        if (extraAttack)
         {
             this.InfusedPiece.AD -= extraAD;
             extraAttack = false;

--- a/Assets/Script/Game/Card/Cards/DonQuixote.cs
+++ b/Assets/Script/Game/Card/Cards/DonQuixote.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DonQuixote : SoulCard
+{
+    private bool extraAttack = false;
+    protected override void Awake()
+    {
+        base.Awake();
+        gameObject.GetComponent<SoulCard>().OnInfuse += InfuseEffect;
+    }
+
+    public void InfuseEffect(ChessPiece chessPiece)
+    {
+        chessPiece.OnStartAttack += StartAttackEffect;
+        chessPiece.OnEndAttack += EndAttackEffect;
+    }
+
+    public void StartAttackEffect(ChessPiece chessPiece)
+    {
+        if(chessPiece.AD >= 100)
+        {
+            this.InfusedPiece.AD += 40;
+            extraAttack = true;
+        }
+    }
+
+    public void EndAttackEffect(ChessPiece chessPiece)
+    {
+        if(extraAttack)
+        {
+            this.InfusedPiece.AD -= 40;
+            extraAttack = false;
+        }
+    }
+}

--- a/Assets/Script/Game/Card/Cards/DonQuixote.cs
+++ b/Assets/Script/Game/Card/Cards/DonQuixote.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class DonQuixote : SoulCard
 {
+    public int standardAD;
+    public int extraAD;
     private bool extraAttack = false;
     protected override void Awake()
     {
@@ -19,9 +21,9 @@ public class DonQuixote : SoulCard
 
     public void StartAttackEffect(ChessPiece chessPiece)
     {
-        if(chessPiece.AD >= 100)
+        if(chessPiece.AD >= standardAD)
         {
-            this.InfusedPiece.AD += 40;
+            this.InfusedPiece.AD += extraAD;
             extraAttack = true;
         }
     }
@@ -30,7 +32,7 @@ public class DonQuixote : SoulCard
     {
         if(extraAttack)
         {
-            this.InfusedPiece.AD -= 40;
+            this.InfusedPiece.AD -= extraAD;
             extraAttack = false;
         }
     }

--- a/Assets/Script/Game/Card/Cards/DonQuixote.cs.meta
+++ b/Assets/Script/Game/Card/Cards/DonQuixote.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06ef52074e405624c8179dc11910aa14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/Card/Cards/Kraken.cs
+++ b/Assets/Script/Game/Card/Cards/Kraken.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class Kraken : SoulCard
+{
+    public int repeat;
+    public int damage;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        gameObject.GetComponent<SoulCard>().OnInfuse += InfuseEffect;
+    }
+
+    public void InfuseEffect(ChessPiece chessPiece)
+    {
+        chessPiece.OnKilled += OnkilledEffect;
+    }
+
+    public void OnkilledEffect(ChessPiece chessPiece)
+    {
+        List<ChessPiece> targets = GameManager.instance.gameData.pieceObjects.Where(obj => obj.pieceColor != GameManager.instance.whiteController.playerColor).ToList();
+        
+        for(int i = 0; i < repeat; i++)
+        {
+            int ran = Random.Range(0, targets.Count);
+            targets[ran].HP -= damage;
+
+            if(!targets[ran].isAlive)
+                targets.Remove(targets[ran]);
+        }
+    }
+
+}

--- a/Assets/Script/Game/Card/Cards/Kraken.cs.meta
+++ b/Assets/Script/Game/Card/Cards/Kraken.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d355616cdf7dbf14c9a68b540e67cab1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/ChessPieces/ChessPiece.cs
+++ b/Assets/Script/Game/ChessPieces/ChessPiece.cs
@@ -119,17 +119,21 @@ abstract public class ChessPiece : TargetableObject
         OnStartAttack?.Invoke(targetPiece);
 
         targetPiece.Attacked(this, attackDamage);
+
+        bool targetIsKilled = !targetPiece.isAlive;
         if (!targetPiece.isAlive)
         {
             OnKill?.Invoke(targetPiece);
-            return true;
+        }
+        else
+        {
+            HP -= targetPiece.attackDamage;
         }
 
-        HP -= targetPiece.attackDamage;
 
         OnEndAttack?.Invoke(targetPiece);
 
-        return false;
+        return targetIsKilled;
     }
     /// <summary>
     /// 

--- a/Assets/Script/Game/PlayerController.cs
+++ b/Assets/Script/Game/PlayerController.cs
@@ -89,7 +89,6 @@ public class PlayerController : MonoBehaviour
                         {
                             if (chosenPiece.Attack(targetPiece))
                             {
-                                gameBoard.KillPiece(targetPiece);
                                 chosenPiece.Move(coordinate);
                                 gameBoard.chessBoard.SetPiecePositionByCoordinate(chosenPiece);
                             }

--- a/Assets/Script/Game/PlayerController.cs
+++ b/Assets/Script/Game/PlayerController.cs
@@ -94,7 +94,7 @@ public class PlayerController : MonoBehaviour
                             }
                             else if (!chosenPiece.isAlive)
                             {
-                                gameBoard.KillPiece(chosenPiece);
+                                //gameBoard.KillPiece(chosenPiece);
                             }
 
                             chosenPiece = null;

--- a/Assets/Script/Game/PlayerController.cs
+++ b/Assets/Script/Game/PlayerController.cs
@@ -94,6 +94,7 @@ public class PlayerController : MonoBehaviour
                             }
                             else if (!chosenPiece.isAlive)
                             {
+                                //이벤트 메커니즘 수정하면서 다시 체크해볼게요
                                 //gameBoard.KillPiece(chosenPiece);
                             }
 

--- a/Assets/Script/UI/LocalTestGameSceneUI.cs
+++ b/Assets/Script/UI/LocalTestGameSceneUI.cs
@@ -31,7 +31,7 @@ public class LocalController : MonoBehaviour
             blackController.enabled = true;
 
             whiteController.TurnEnd();
-            blackController.OnOpponentTurnEnd();
+            blackController.OnOpponentTurnEnd?.Invoke();
         }
         else
         {
@@ -41,7 +41,7 @@ public class LocalController : MonoBehaviour
             whiteController.enabled = true;
 
             blackController.TurnEnd();
-            whiteController.OnOpponentTurnEnd();
+            whiteController.OnOpponentTurnEnd?.Invoke();
         }
     }
 


### PR DESCRIPTION
아벨 / 크라켄 / 돈키호테 카드 구현

아벨 / 크라켄 / 돈키호테 카드 관련 스크립트 / 프리펩 추가
처형 카드 능력 한글화

+) killpiece가 kill()에서 한번, OnClickBoardSquare()에서 한번 그래서 중복으로 실행되길래 한번만 실행되는게 맞는 것 같아서 일단 없애두었는데 의도된 건지 잘 모르겠습니다.

++) 아벨 카드 관련 코멘트
- 내 유언 능력이 작동될 때 killpiece() 내 좌표 조정 이후에 OnClickBoardSquare() 내 좌표 조정이 이루어져 능력으로 인해 죽게 되는 기물의 좌표가 무덤 좌표로 이동하지 않는 문제가 존재합니다.
- 아벨 코드 내 자신의 턴인지 확인하는 부분 현재는 드로우 ~  내턴 종료 시 까지 플래그로 알 수 있게 (white controller 기준으로) 임시로 해두었는데, 나중에 더 좋은 방식으로 보완할 수 있을 것 같습니다.
- Onkilled 에서 누가 자신을 죽였는지에 대한 정보가 전달되지 않아서 현재는 자신을 가장 최근에 공격한 기물을 없애도록 임시로 구현되어 있습니다. 이 부분도 수정이 필요해 보입니다.