### PR TITLE
코스트 기능, 기물 정보, 악세서리 구현

### DIFF
--- a/Assets/Prefabs/Game/Cards/Norse/Soul_MotherBear.prefab
+++ b/Assets/Prefabs/Game/Cards/Norse/Soul_MotherBear.prefab
@@ -105,4 +105,5 @@ MonoBehaviour:
   pieceRestriction: 9
   _AD: 35
   _HP: 50
+  accessory: {fileID: 3173611911874920962, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
   InfusedPiece: {fileID: 0}

--- a/Assets/Prefabs/Game/Cards/Western/Soul_Behemoth.prefab
+++ b/Assets/Prefabs/Game/Cards/Western/Soul_Behemoth.prefab
@@ -87,6 +87,7 @@ MonoBehaviour:
   pieceRestriction: 8
   _AD: 70
   _HP: 70
+  accessory: {fileID: 8466492560351693723, guid: e066d4a8a2e33e84e9d7c13b4664361a, type: 3}
   InfusedPiece: {fileID: 0}
 --- !u!114 &5415071180265959741 stripped
 MonoBehaviour:

--- a/Assets/Prefabs/Game/Cards/Western/Soul_LadyOfTheLake.prefab
+++ b/Assets/Prefabs/Game/Cards/Western/Soul_LadyOfTheLake.prefab
@@ -99,4 +99,5 @@ MonoBehaviour:
   pieceRestriction: 20
   _AD: 40
   _HP: 40
+  accessory: {fileID: 4166747416282027478, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
   InfusedPiece: {fileID: 0}

--- a/Assets/Prefabs/Game/Cards/Western/Soul_MorganLeFay.prefab
+++ b/Assets/Prefabs/Game/Cards/Western/Soul_MorganLeFay.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
   pieceRestriction: 20
   _AD: 20
   _HP: 30
+  accessory: {fileID: 6792036558972093160, guid: e442eaa8a519b4f43bb1d7c9c421a2e2, type: 3}
   InfusedPiece: {fileID: 0}
 --- !u!114 &8465317945174799330 stripped
 MonoBehaviour:

--- a/Assets/Prefabs/Game/ChessPieces/Accessories.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 983cd7f6e3f01c74a9402d8136318a8e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Greek.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Greek.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48703fd74870ef64f9e3caef0600feac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Norse.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Norse.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 308d8983731cb8c4ba39f57a2387cea8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Norse/PieceAccessory_MotherBear.prefab
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Norse/PieceAccessory_MotherBear.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1574480356281980884
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6844158551371586400, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Name
+      value: PieceAccessory_MotherBear
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955233066505038265, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Color.b
+      value: 0.08940014
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955233066505038265, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Color.g
+      value: 0.26719698
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955233066505038265, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Color.r
+      value: 0.46226418
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Norse/PieceAccessory_MotherBear.prefab.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Norse/PieceAccessory_MotherBear.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 18e917f0b45ca214d9f221bdde92267d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/PieceAccessory.prefab
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/PieceAccessory.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5188252417228110703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7820116431390071764}
+  - component: {fileID: -684891862434018890}
+  - component: {fileID: 3398097136901010905}
+  m_Layer: 0
+  m_Name: PieceAccessory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7820116431390071764
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5188252417228110703}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &-684891862434018890
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5188252417228110703}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 1913470231
+  m_SortingLayer: 3
+  m_SortingOrder: 1
+  m_Sprite: {fileID: -2413806693520163455, guid: 56a8257eefd1eb34b8ab3e23fab776c0, type: 3}
+  m_Color: {r: 1, g: 0.3915094, b: 0.3915094, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.25, y: 0.25}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &3398097136901010905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5188252417228110703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b8b6e9e87b503b4183b75091290dbb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/PieceAccessory.prefab.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/PieceAccessory.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b9a964e68f9034545a5bb74baf4cd095
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Western.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Western.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1bb208bad54a9a4c95bae9a062a3e86
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_Behemoth.prefab
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_Behemoth.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6446314732935760281
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5414162905173068980, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_Name
+      value: PieceAccessory_Behemoth
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8044618715992566799, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8456737646277951085, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_Color.b
+      value: 0.11347455
+      objectReference: {fileID: 0}
+    - target: {fileID: 8456737646277951085, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_Color.g
+      value: 0.3207547
+      objectReference: {fileID: 0}
+    - target: {fileID: 8456737646277951085, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}
+      propertyPath: m_Color.r
+      value: 0.14118198
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 18e917f0b45ca214d9f221bdde92267d, type: 3}

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_Behemoth.prefab.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_Behemoth.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e066d4a8a2e33e84e9d7c13b4664361a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_LadyOfTheLake.prefab
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_LadyOfTheLake.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1655976547615891471
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -684891862434018890, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_Color.b
+      value: 0.8300528
+      objectReference: {fileID: 0}
+    - target: {fileID: -684891862434018890, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_Color.g
+      value: 0.8679245
+      objectReference: {fileID: 0}
+    - target: {fileID: -684891862434018890, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_Color.r
+      value: 0.08597365
+      objectReference: {fileID: 0}
+    - target: {fileID: 5188252417228110703, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_Name
+      value: PieceAccessory_LadyOfTheLake
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7820116431390071764, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b9a964e68f9034545a5bb74baf4cd095, type: 3}

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_LadyOfTheLake.prefab.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_LadyOfTheLake.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9393d6577a23d1344baba662ba1e6077
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_MorganLeFay.prefab
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_MorganLeFay.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7462864741950281534
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6844158551371586400, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Name
+      value: PieceAccessory_MorganLeFay
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955233066505038265, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Color.b
+      value: 0.4669811
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955233066505038265, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Color.g
+      value: 0.48851278
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955233066505038265, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8826377503912672219, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9393d6577a23d1344baba662ba1e6077, type: 3}

--- a/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_MorganLeFay.prefab.meta
+++ b/Assets/Prefabs/Game/ChessPieces/Accessories/Western/PieceAccessory_MorganLeFay.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e442eaa8a519b4f43bb1d7c9c421a2e2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/ChessPieces/PieceInfo.prefab
+++ b/Assets/Prefabs/Game/ChessPieces/PieceInfo.prefab
@@ -1,0 +1,490 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &248318539175786092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5845690799093950004}
+  - component: {fileID: 1594983728884485668}
+  - component: {fileID: 4796838401652427514}
+  m_Layer: 0
+  m_Name: PieceInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5845690799093950004
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 248318539175786092}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2722515557678878313}
+  - {fileID: 3288877231917063545}
+  - {fileID: 4554367533535448904}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1594983728884485668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 248318539175786092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0df611e1e2d3e76489e62b5c35f47709, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  infoText: {fileID: 1936259521845263450}
+--- !u!210 &4796838401652427514
+SortingGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 248318539175786092}
+  m_Enabled: 1
+  m_SortingLayerID: -295583789
+  m_SortingLayer: 5
+  m_SortingOrder: 10
+  m_SortAtRoot: 0
+--- !u!1 &1778595151190330130
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4554367533535448904}
+  - component: {fileID: 3064102741520304492}
+  - component: {fileID: 1936259521845263450}
+  m_Layer: 0
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4554367533535448904
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1778595151190330130}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5845690799093950004}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 4, y: 4}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &3064102741520304492
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1778595151190330130}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: -4786860882074376051, guid: 1f223abdfec106146b482f4dda3ce5dc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -295583789
+  m_SortingLayer: 5
+  m_SortingOrder: 2
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &1936259521845263450
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1778595151190330130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC885\uB958 : \uD3F0\nHP : 55 / 55\nAD : 45\n\n[\uBD80\uC5EC\uB41C \uC601\uD63C]\n\uC5C6\uC74C\n\n[\uBC84\uD504
+    \uD6A8\uACFC]\n\uC5C6\uC74C\n\n[\uB514\uBC84\uD504]\n\uC5C6\uC74C"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 1f223abdfec106146b482f4dda3ce5dc, type: 2}
+  m_sharedMaterial: {fileID: -4786860882074376051, guid: 1f223abdfec106146b482f4dda3ce5dc, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 3
+  m_fontSizeBase: 3
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 3064102741520304492}
+  m_maskType: 0
+--- !u!1 &4919973301775475137
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3288877231917063545}
+  - component: {fileID: 3494088970320049408}
+  - component: {fileID: 9160440921819862131}
+  m_Layer: 0
+  m_Name: InfoTitle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3288877231917063545
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4919973301775475137}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5845690799093950004}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 2.5}
+  m_SizeDelta: {x: 4, y: 0.5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &3494088970320049408
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4919973301775475137}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: -4786860882074376051, guid: 1f223abdfec106146b482f4dda3ce5dc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -295583789
+  m_SortingLayer: 5
+  m_SortingOrder: 2
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &9160440921819862131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4919973301775475137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uAE30\uBB3C \uC815\uBCF4"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 1f223abdfec106146b482f4dda3ce5dc, type: 2}
+  m_sharedMaterial: {fileID: -4786860882074376051, guid: 1f223abdfec106146b482f4dda3ce5dc, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 4
+  m_fontSizeBase: 4
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 3494088970320049408}
+  m_maskType: 0
+--- !u!1 &8845279360359958550
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2722515557678878313}
+  - component: {fileID: 6423998992748022534}
+  m_Layer: 0
+  m_Name: Square
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2722515557678878313
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8845279360359958550}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5845690799093950004}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6423998992748022534
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8845279360359958550}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -295583789
+  m_SortingLayer: 5
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.8784314}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/Game/ChessPieces/PieceInfo.prefab.meta
+++ b/Assets/Prefabs/Game/ChessPieces/PieceInfo.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f09fd129a154794e8cebcd82ef9b00a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/SoulOrb.prefab
+++ b/Assets/Prefabs/Game/SoulOrb.prefab
@@ -1,0 +1,273 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3176916607182412570
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 957088572025518792}
+  - component: {fileID: 6612408381404500810}
+  - component: {fileID: 4935592771606389188}
+  m_Layer: 0
+  m_Name: soulEssenceText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &957088572025518792
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3176916607182412570}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 691786838047155631}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &6612408381404500810
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3176916607182412570}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1733247665
+  m_SortingLayer: 4
+  m_SortingOrder: 1
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &4935592771606389188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3176916607182412570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 1
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 7
+  m_fontSizeBase: 7
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 6612408381404500810}
+  m_maskType: 0
+--- !u!1 &8799467538424568598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 691786838047155631}
+  - component: {fileID: 543928485649004982}
+  - component: {fileID: -6293375645755760837}
+  m_Layer: 0
+  m_Name: SoulOrb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &691786838047155631
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8799467538424568598}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 957088572025518792}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &543928485649004982
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8799467538424568598}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1733247665
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 28d3e7d3d20d2004aa0289ff19cdcadb, type: 3}
+  m_Color: {r: 0.55677783, g: 0.26637593, b: 0.7735849, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.25, y: 0.25}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &-6293375645755760837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8799467538424568598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c371e07879a45944b455a0d95866948, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  soulEssenceText: {fileID: 4935592771606389188}
+  playerColor: 0

--- a/Assets/Prefabs/Game/SoulOrb.prefab.meta
+++ b/Assets/Prefabs/Game/SoulOrb.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6c164027602fd41459ade190044e02be
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TestScenes/GameScene_PJH.unity
+++ b/Assets/Scenes/TestScenes/GameScene_PJH.unity
@@ -206,6 +206,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
   m_PrefabInstance: {fileID: 27941302}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &252833834
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 463008058}
+    m_Modifications:
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8799467538424568598, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_Name
+      value: WhiteSoulOrb
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3176916607182412570, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 6c164027602fd41459ade190044e02be, type: 3}
+--- !u!114 &252833835 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 252833834}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c371e07879a45944b455a0d95866948, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &252833836 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 252833834}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &430605365
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -388,6 +468,8 @@ Transform:
   m_Children:
   - {fileID: 625501410}
   - {fileID: 1635301581}
+  - {fileID: 252833836}
+  - {fileID: 1335561087}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &463008059
@@ -634,6 +716,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerColor: 0
   gameBoard: {fileID: 1132824878}
+  soulOrb: {fileID: 252833835}
   isUsingCard: 0
 --- !u!4 &625501410
 Transform:
@@ -1572,7 +1655,9 @@ MonoBehaviour:
   bottomPlayerColor: 0
   chessBoard: {fileID: 1628251987148721090}
   cardBoard: {fileID: 1951553768}
+  pieceInfo: {fileID: 1594983728884485668, guid: 6f09fd129a154794e8cebcd82ef9b00a, type: 3}
   whiteController: {fileID: 625501409}
+  isShowingPieceInfo: 0
 --- !u!1001 &1184252153
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1817,6 +1902,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
   m_PrefabInstance: {fileID: 1218359108}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1335561086
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 463008058}
+    m_Modifications:
+    - target: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: playerColor
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8799467538424568598, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_Name
+      value: BlackSoulOrb
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3176916607182412570, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 6c164027602fd41459ade190044e02be, type: 3}
+--- !u!4 &1335561087 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 1335561086}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1335561088 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 1335561086}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c371e07879a45944b455a0d95866948, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1387144019
 GameObject:
   m_ObjectHideFlags: 0
@@ -2237,6 +2402,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerColor: 1
   gameBoard: {fileID: 1132824878}
+  soulOrb: {fileID: 1335561088}
   isUsingCard: 0
 --- !u!4 &1635301581
 Transform:

--- a/Assets/Script/Game/BoardSquare.cs
+++ b/Assets/Script/Game/BoardSquare.cs
@@ -58,6 +58,20 @@ public class BoardSquare : MonoBehaviour
     private void OnMouseUp()
     {
         _onClick.Invoke(coordinate);
+        if (GameManager.instance.gameData.GetPiece(coordinate))
+            GameManager.instance.ShowPieceInfo(GameManager.instance.gameData.GetPiece(coordinate));
+    }
+    private void OnMouseEnter()
+    {
+        //카드 사용 중인지 체크해서 그 때는 기물 정보 표시 X
+        //BlackController 없어서 검정 턴에는 기물 위에 올리면 오류
+        if (GameManager.instance.gameData.GetPiece(coordinate) && (!GameManager.instance.CurrentPlayerController().isUsingCard))
+            GameManager.instance.ShowPieceInfo(GameManager.instance.gameData.GetPiece(coordinate));
+    }
+    private void OnMouseExit()
+    {
+        if (GameManager.instance.isShowingPieceInfo)
+            GameManager.instance.HidePieceInfo();
     }
 
     public BoardSquare(Vector2Int coordinate, Sprite sprite)

--- a/Assets/Script/Game/Card/Card.cs
+++ b/Assets/Script/Game/Card/Card.cs
@@ -79,9 +79,13 @@ public class Card : TargetableObject
 
     public virtual bool TryUse()
     {
-        GameManager.instance.whiteController.UseCard(this);
-
-        return true;
+        if (GameManager.instance.CurrentPlayerData().soulEssence >= cost)
+        {
+            //코스트 제거는 PlayerController.UseCardEffect에서 수행함 (타겟 지정 후 효과 발동한 다음 코스트 제거)
+            GameManager.instance.CurrentPlayerController().UseCard(this);
+            return true;
+        }
+        return false;
     }
 
     //public abstract void Use();

--- a/Assets/Script/Game/Card/SoulCard.cs
+++ b/Assets/Script/Game/Card/SoulCard.cs
@@ -39,6 +39,9 @@ public class SoulCard : Card
     [SerializeField]
     private int _HP;
 
+    //영혼카드 프리팹마다 대응하는 악세서리 프리팹 인스펙터에 지정 필요
+    public PieceAccessory accessory;
+
     [HideInInspector]
     public ChessPiece InfusedPiece;
 

--- a/Assets/Script/Game/ChessPieces/Accessories.meta
+++ b/Assets/Script/Game/ChessPieces/Accessories.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf25fa7a310493649828324bb1e5c299
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/ChessPieces/Accessories/Greek.meta
+++ b/Assets/Script/Game/ChessPieces/Accessories/Greek.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de3ad9afd2758b94cab48de8baa7e45a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/ChessPieces/Accessories/Norse.meta
+++ b/Assets/Script/Game/ChessPieces/Accessories/Norse.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c66fce5584bc0b54c8a9831b51eec222
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/ChessPieces/Accessories/PieceAccessory.cs
+++ b/Assets/Script/Game/ChessPieces/Accessories/PieceAccessory.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PieceAccessory : MonoBehaviour
+{
+    //악세서리가 단순 스프라이트가 아니라 여러 비주얼 효과가 있는 오브젝트일 수 있으므로 프리팹으로 함
+    //기능 추가할때 이 스크립트를 상속받아 작성바람
+}

--- a/Assets/Script/Game/ChessPieces/Accessories/PieceAccessory.cs.meta
+++ b/Assets/Script/Game/ChessPieces/Accessories/PieceAccessory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b8b6e9e87b503b4183b75091290dbb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/ChessPieces/Accessories/Western.meta
+++ b/Assets/Script/Game/ChessPieces/Accessories/Western.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 726b9cd0d453c61478c42bb06f5a0a1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/ChessPieces/ChessPiece.cs
+++ b/Assets/Script/Game/ChessPieces/ChessPiece.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using TMPro;
 using UnityEngine;
 
@@ -82,6 +83,8 @@ abstract public class ChessPiece : TargetableObject
     [SerializeField]
     private int _maxHP;
 
+    //악세서리
+    private PieceAccessory accessory = null;
 
     private PieceObject pieceObject;
 
@@ -183,6 +186,12 @@ abstract public class ChessPiece : TargetableObject
         soul.transform.localPosition = Vector3.zero;
         soul.gameObject.SetActive(false);
 
+        //악세서리 오브젝트를 기물에 자식으로 생성
+        if (soul.accessory != null)
+        {
+            accessory = Instantiate(soul.accessory, transform.position, Quaternion.identity);
+            accessory.transform.SetParent(transform);
+        }
         targetSoul.InfusedPiece = this;
 
         maxHP += soul.HP;

--- a/Assets/Script/Game/ChessPieces/PieceInfo.cs
+++ b/Assets/Script/Game/ChessPieces/PieceInfo.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class PieceInfo : MonoBehaviour
+{
+    [SerializeField]
+    private TextMeshPro infoText;
+    
+    public void EditDescription(ChessPiece chessPiece)
+    {
+        string pieceTypeText = "없음";
+        //string pieceBuffText = "없음";
+        //string pieceDebuffText = "없음";
+        string temp = "";
+
+        switch(chessPiece.pieceType)
+        {
+            case ChessPiece.PieceType.Pawn : pieceTypeText = "폰"; break;
+            case ChessPiece.PieceType.Knight : pieceTypeText = "나이트"; break;
+            case ChessPiece.PieceType.Bishop : pieceTypeText = "비숍"; break;
+            case ChessPiece.PieceType.Rook : pieceTypeText = "룩"; break;
+            case ChessPiece.PieceType.Quene : pieceTypeText = "퀸"; break;
+            case ChessPiece.PieceType.King : pieceTypeText = "킹"; break;
+            default : pieceTypeText = "오류"; break;
+        }
+
+        temp = "종류 : " + pieceTypeText + "\nHP : " + chessPiece.HP + " / " + chessPiece.maxHP;
+        if (chessPiece.soul != null) temp += "(+" + chessPiece.soul.HP + ")";
+        temp += "\nAD : " + chessPiece.AD;
+        if (chessPiece.soul != null) temp += "(+" + chessPiece.soul.AD + ")";
+        if (chessPiece.soul != null) temp += "\n \n[부여된 영혼]\n" + chessPiece.soul.cardName;
+        //TODO : 버프/디버프 기능 완성 후 BuffText/DebuffText 조합 필요
+
+        infoText.text = temp;
+    }
+}

--- a/Assets/Script/Game/ChessPieces/PieceInfo.cs.meta
+++ b/Assets/Script/Game/ChessPieces/PieceInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0df611e1e2d3e76489e62b5c35f47709
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/GameManager.cs
+++ b/Assets/Script/Game/GameManager.cs
@@ -13,6 +13,7 @@ public class GameManager : MonoBehaviour
     public GameManager.PlayerColor bottomPlayerColor;
     public ChessBoard chessBoard;
     public GameObject cardBoard;
+    public PieceInfo pieceInfo; //기물 정보 프리팹
 
     public PlayerController whiteController;
 
@@ -40,6 +41,10 @@ public class GameManager : MonoBehaviour
         }
 
         chessBoard.SetBoardSquares(gameData);
+
+        //코스트 초기화(선공이 1, 후공이 0, 턴 종료 시 상대방 코스트 증가)
+        gameData.playerBlack.soulOrbs = gameData.playerBlack.soulEssence = 0;
+        gameData.playerWhite.soulOrbs = gameData.playerWhite.soulEssence = 1;
     }
 
     public BoardSquare GetBoardSquare(Vector2Int coordinate)
@@ -73,6 +78,39 @@ public class GameManager : MonoBehaviour
             return;
 
         Destroy(showedCard.gameObject);
+    }
+
+    //기물 정보 표시
+    PieceInfo showedPieceInfo = null;
+    public bool isShowingPieceInfo = false;
+    public void ShowPieceInfo(ChessPiece piece)
+    {
+        if (showedPieceInfo != null)
+            HidePieceInfo();
+
+        showedPieceInfo = Instantiate(pieceInfo, cardBoard.transform.position, Quaternion.identity);
+        showedPieceInfo.EditDescription(piece);
+        isShowingPieceInfo = true;
+    }
+    public void HidePieceInfo()
+    {
+        if (showedPieceInfo == null)
+            return;
+
+        Destroy(showedPieceInfo.gameObject);
+        isShowingPieceInfo = false;
+    }
+
+    //현재 턴 진행 중인 Enabled 플레이어 데이터 접근
+    public PlayerData CurrentPlayerData()
+    {
+        if (whiteController.enabled) return gameData.playerWhite;
+        else return gameData.playerBlack;
+    }
+    public PlayerController CurrentPlayerController()
+    {
+        if (whiteController.enabled) return whiteController;
+        else return null; //blackController
     }
 
     [System.Serializable]

--- a/Assets/Script/Game/PlayerController.cs
+++ b/Assets/Script/Game/PlayerController.cs
@@ -9,6 +9,7 @@ public class PlayerController : MonoBehaviour
 {
     public GameManager.PlayerColor playerColor;
     public GameManager gameBoard;
+    public SoulOrb soulOrb; //코스트 프리팹
 
     ChessPiece chosenPiece = null;
     List<Vector2Int> movableCoordinates = new List<Vector2Int>();
@@ -197,6 +198,7 @@ public class PlayerController : MonoBehaviour
     public void UseCardEffect()
     {
         UsingCard.EffectOnCardUsed.EffectAction();
+        GameManager.instance.CurrentPlayerData().soulEssence -= UsingCard.cost;
 
         if (!(UsingCard is SoulCard))
             UsingCard.Destroy();
@@ -218,5 +220,18 @@ public class PlayerController : MonoBehaviour
     public void TurnEnd()
     {
         OnMyTurnEnd?.Invoke();
+        //턴 종료 시 상대 코스트 회복
+        if (playerColor == GameManager.PlayerColor.White)
+        {
+            if (GameManager.instance.gameData.playerBlack.soulOrbs < 10)
+                GameManager.instance.gameData.playerBlack.soulOrbs++;
+            GameManager.instance.gameData.playerBlack.soulEssence = GameManager.instance.gameData.playerBlack.soulOrbs;
+        }
+        else
+        {
+            if (GameManager.instance.gameData.playerWhite.soulOrbs < 10)
+                GameManager.instance.gameData.playerWhite.soulOrbs++;
+            GameManager.instance.gameData.playerWhite.soulEssence = GameManager.instance.gameData.playerWhite.soulOrbs;
+        }
     }
 }

--- a/Assets/Script/Game/SoulOrb.cs
+++ b/Assets/Script/Game/SoulOrb.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class SoulOrb : MonoBehaviour
+{
+    public TextMeshPro soulEssenceText;
+    public GameManager.PlayerColor playerColor;
+
+    public void Update() //최적화하려면 더 나은 방식으로 바꿀 수 있을 것 같음
+    {
+        if (playerColor == GameManager.PlayerColor.White)
+        {
+            soulEssenceText.text = GameManager.instance.gameData.playerWhite.soulEssence.ToString();
+        }
+        else
+        {
+            soulEssenceText.text = GameManager.instance.gameData.playerBlack.soulEssence.ToString();
+        }
+    }
+}

--- a/Assets/Script/Game/SoulOrb.cs.meta
+++ b/Assets/Script/Game/SoulOrb.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c371e07879a45944b455a0d95866948
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/GameObjects/ChessPieces/Accessories.meta
+++ b/Assets/Sprites/GameObjects/ChessPieces/Accessories.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2a5432a68f256844780b15d2e000613a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
■ 코스트 기능
- SoulOrb 프리팹, 스크립트 추가
- 각 색깔 PlayerController의 인스펙터에 SoulOrb 추가해야함
- GameManager에 현재 턴인 플레이어 데이터/컨트롤러 정보를 enabled로 판단해서 가져오는 CurrentPlayerData(), CurrentPlayerController() 추가
- SoulOrb의 Update()에서 코스트 수치를 텍스트로 넣고 있음

■ 기물 정보
- PieceInfo 프리팹, 스크립트 추가 (레이어는 Card의 10 정도)
- GameManager의 인스펙터에 PieceInfo 프리팹 추가, isShowingPieceInfo 부울 변수로 표시 중인지 구별
- BoardSquare 스크립트에서 마우스 클릭/Enter/Exit 때마다 정보 갱신

■ 기물 악세서리
- PieceAccessory 스크립트 추가
- 테스트용 어미 곰, 베히모스, 호수의 여인, 모르간 르 페이 PieceAccessory 프리팹 추가 (단순 스프라이트가 아닌 시각적 효과 스크립트가 들어갈 것까지 고려)
- SoulCard 인스펙터에 Accessory 프리팹 추가(없어도 됨)
- 자식 오브젝트로 ChessPiece에 Accessory 추가하는 방식

※TODO
- 버프/디버프 시스템 구현 후 기물 정보에 추가
- BlackController 추가되면 코스트 갱신 시점을 턴 종료로 한정시켜 호출 가능
- 카드 사용 실패 시 핸드로 원위치 시키는 기능 추가 필요

주석 참고 후 질문이나 수정사항 있으시면 말씀해주시기 바랍니다