### PR TITLE
효과 발동 조건 및 영혼 효과 제거 구현

### DIFF
--- a/Assets/Scenes/TestScenes/GameScene_WKH.unity
+++ b/Assets/Scenes/TestScenes/GameScene_WKH.unity
@@ -122,13 +122,3642 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &4027578
+--- !u!1 &96209569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 96209571}
+  - component: {fileID: 96209570}
+  m_Layer: 0
+  m_Name: WhitePlayerController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &96209570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 96209569}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1eac50d157602604689f8edef6de9a87, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerColor: 0
+  gameBoard: {fileID: 1683396308}
+  soulOrb: {fileID: 1354575176}
+  isUsingCard: 0
+  isMyTurn: 1
+--- !u!4 &96209571
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 96209569}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.048588753, y: -0.10904288, z: -0.003311988}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1649245420}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &177257575
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 369323392}
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 791631163023233955, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_Name
+      value: WhiteRook
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+--- !u!4 &177257576 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+  m_PrefabInstance: {fileID: 177257575}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &211787238
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 211787240}
+  - component: {fileID: 211787239}
+  m_Layer: 0
+  m_Name: BlackPlayerController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &211787239
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 211787238}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1eac50d157602604689f8edef6de9a87, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerColor: 1
+  gameBoard: {fileID: 1683396308}
+  soulOrb: {fileID: 1859173220}
+  isUsingCard: 0
+  isMyTurn: 0
+--- !u!4 &211787240
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 211787238}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.048588753, y: -0.10904288, z: -0.003311988}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1649245420}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &214360096
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -4506486621274620446, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -4506486621274620446, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: coordinate.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 200357043479895921, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_Name
+      value: WhiteKnight (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 36266483366b90e418695571e078f9f5, type: 3}
+--- !u!4 &214360097 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 36266483366b90e418695571e078f9f5, type: 3}
+  m_PrefabInstance: {fileID: 214360096}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &245704525
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -2627985642760532060, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: coordinate.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1115585259782103859, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: coordinate.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5347852299346591580, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      propertyPath: m_Name
+      value: WhiteBishop
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+--- !u!4 &245704526 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
+  m_PrefabInstance: {fileID: 245704525}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &396808170
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_Name
+      value: BlackKnight
+      objectReference: {fileID: 0}
+    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+--- !u!4 &396808171 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+  m_PrefabInstance: {fileID: 396808170}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &421155004
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -15532680628458650, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: gameBoard
+      value: 
+      objectReference: {fileID: 1683396308}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 422342884666363343, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3012661983670039608, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+      propertyPath: m_Name
+      value: GameManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6075da18f564c8b439dbba55ec0eccac, type: 3}
+--- !u!1001 &473590877
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 791631163023233955, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_Name
+      value: BlackKing
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6404625500466290932, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6404625500466290932, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7421589679604356431, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7421589679604356431, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+--- !u!4 &473590878 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
+  m_PrefabInstance: {fileID: 473590877}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &476952871
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_Name
+      value: WhitePawn (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+--- !u!4 &476952872 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+  m_PrefabInstance: {fileID: 476952871}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &518841780
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 518841782}
+  - component: {fileID: 518841781}
+  m_Layer: 0
+  m_Name: CardBoard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &518841781
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 518841780}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1733247665
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 560c1f21b8beb5b48be8d9bc129efede, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &518841782
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 518841780}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -5.8, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &607782380
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_Name
+      value: WhitePawn (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+--- !u!4 &607782381 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+  m_PrefabInstance: {fileID: 607782380}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &726723707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 726723708}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &726723708
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 726723707}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.1299443, y: -1.4086864, z: -0.0017261512}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &754246361
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &754246362 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 754246361}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &805565551
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &805565552 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 805565551}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &903415350
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 791631163023233955, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_Name
+      value: WhiteQueen
+      objectReference: {fileID: 0}
+    - target: {fileID: 1204250401167620467, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4662516292740937369, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4662516292740937369, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: coordinate.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+--- !u!4 &903415351 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
+  m_PrefabInstance: {fileID: 903415350}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &905005322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 905005325}
+  - component: {fileID: 905005324}
+  - component: {fileID: 905005323}
+  m_Layer: 0
+  m_Name: DeckCountText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &905005323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905005322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 10 cards left
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 3
+  m_fontSizeBase: 3
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 905005324}
+  m_maskType: 0
+--- !u!23 &905005324
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905005322}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1209845637
+  m_SortingLayer: 7
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!224 &905005325
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905005322}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1840355142}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -1.8}
+  m_SizeDelta: {x: 20, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &917355678
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_Name
+      value: WhitePawn (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+--- !u!4 &917355679 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+  m_PrefabInstance: {fileID: 917355678}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1090551260
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 791631163023233955, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_Name
+      value: BlackRook (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5606874248494239254, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5606874248494239254, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8771360765114331950, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8771360765114331950, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+--- !u!4 &1090551261 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+  m_PrefabInstance: {fileID: 1090551260}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1114100885
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &1114100886 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 1114100885}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1207938936
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_Name
+      value: WhitePawn (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+--- !u!4 &1207938937 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+  m_PrefabInstance: {fileID: 1207938936}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1224059684
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &1224059685 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 1224059684}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1248443663
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_Name
+      value: BlackKnight (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+--- !u!4 &1248443664 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
+  m_PrefabInstance: {fileID: 1248443663}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1255084449
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -4506486621274620446, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 200357043479895921, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_Name
+      value: WhiteKnight
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 36266483366b90e418695571e078f9f5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 36266483366b90e418695571e078f9f5, type: 3}
+--- !u!4 &1255084450 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 36266483366b90e418695571e078f9f5, type: 3}
+  m_PrefabInstance: {fileID: 1255084449}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1283634761
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_Name
+      value: WhitePawn (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+--- !u!4 &1283634762 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+  m_PrefabInstance: {fileID: 1283634761}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1323045554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1323045556}
+  - component: {fileID: 1323045555}
+  m_Layer: 0
+  m_Name: DeckTester
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1323045555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323045554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99a5ecd33958b4d479d5c003aaf93576, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CardBoard: {fileID: 518841780}
+  gameBoard: {fileID: 1683396308}
+  hand:
+  - {fileID: 7433252666421529211, guid: fc310b2ab5a30de4298b4aea18a015f4, type: 3}
+  - {fileID: 1292469394887977406, guid: 69acd9f53abcc974da0de5adf88dba59, type: 3}
+  deck:
+  - {fileID: 4824830457768495894, guid: dc0e4c5991c664d4aaaad1229ca79999, type: 3}
+  - {fileID: -2815551797691118998, guid: 2d9947a9ca0af554ebef3f3b895f3d78, type: 3}
+  - {fileID: 3604200065000529882, guid: 69c628af0606ded408e60e35428eab89, type: 3}
+  - {fileID: 599667399022218461, guid: ff82128eca4e7994fb3e11360893a803, type: 3}
+--- !u!4 &1323045556
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323045554}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.57287, y: -2.0774097, z: -0.014950933}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1343568474
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &1343568475 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 1343568474}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1354575175
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1649245420}
+    m_Modifications:
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8799467538424568598, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_Name
+      value: WhiteSoulOrb
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3176916607182412570, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 6c164027602fd41459ade190044e02be, type: 3}
+--- !u!114 &1354575176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 1354575175}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c371e07879a45944b455a0d95866948, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1354575177 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 1354575175}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1422035892
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -8797728076416791713, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -8797728076416791713, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: coordinate.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_Name
+      value: WhiteKing
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7421589679604356431, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      propertyPath: coordinate.x
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+--- !u!4 &1422035893 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
+  m_PrefabInstance: {fileID: 1422035892}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1430963648
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &1430963649 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 1430963648}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1433347277
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_Name
+      value: WhitePawn
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+--- !u!4 &1433347278 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+  m_PrefabInstance: {fileID: 1433347277}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1479606727
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 791631163023233955, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_Name
+      value: BlackRook
+      objectReference: {fileID: 0}
+    - target: {fileID: 5606874248494239254, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8771360765114331950, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+--- !u!4 &1479606728 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
+  m_PrefabInstance: {fileID: 1479606727}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1502630787
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5347852299346591580, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_Name
+      value: BlackBishop
+      objectReference: {fileID: 0}
+    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 762e806020df41b488cb109713e1642f, type: 3}
+--- !u!4 &1502630788 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 762e806020df41b488cb109713e1642f, type: 3}
+  m_PrefabInstance: {fileID: 1502630787}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1533233091
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &1533233092 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 1533233091}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1540373066
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1540373070}
+  - component: {fileID: 1540373069}
+  - component: {fileID: 1540373068}
+  - component: {fileID: 1540373067}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1540373067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1540373066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!81 &1540373068
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1540373066}
+  m_Enabled: 1
+--- !u!20 &1540373069
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1540373066}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1540373070
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1540373066}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1586896027
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 791631163023233955, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_Name
+      value: BlackQueen
+      objectReference: {fileID: 0}
+    - target: {fileID: 1204250401167620467, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1204250401167620467, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3805196673899827496, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: coordinate.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3805196673899827496, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+--- !u!4 &1586896028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
+  m_PrefabInstance: {fileID: 1586896027}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1619386276
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5347852299346591580, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: m_Name
+      value: BlackBishop (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      propertyPath: coordinate.y
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 762e806020df41b488cb109713e1642f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 762e806020df41b488cb109713e1642f, type: 3}
+--- !u!4 &1619386277 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 762e806020df41b488cb109713e1642f, type: 3}
+  m_PrefabInstance: {fileID: 1619386276}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1649245416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1649245420}
+  - component: {fileID: 1649245419}
+  - component: {fileID: 1649245418}
+  - component: {fileID: 1649245417}
+  m_Layer: 0
+  m_Name: LocalController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1649245417
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649245416}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &1649245418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649245416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b67f8aaf4ec06e5418ad0c5786a7c7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  whiteButton: {fileID: 21300000, guid: 28d3e7d3d20d2004aa0289ff19cdcadb, type: 3}
+  blackButton: {fileID: 21300000, guid: edc8a02128854254da50760cf1530179, type: 3}
+  whiteController: {fileID: 96209570}
+  blackController: {fileID: 211787239}
+--- !u!212 &1649245419
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649245416}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1733247665
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 28d3e7d3d20d2004aa0289ff19cdcadb, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1649245420
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649245416}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 8, y: 0, z: -0.035696927}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 211787240}
+  - {fileID: 96209571}
+  - {fileID: 1859173221}
+  - {fileID: 1354575177}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1683396307
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1683396309}
+  - component: {fileID: 1683396310}
+  - component: {fileID: 1683396308}
+  m_Layer: 0
+  m_Name: GameBoard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1683396308
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1683396307}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b1464a3476d9b6409b3f459335d71c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameData:
+    pieceObjects: []
+    graveyard: []
+    playerWhite:
+      soulOrbs: 0
+      soulEssence: 0
+      maxHandCardCount: 8
+      mulliganHandCount: 4
+      deck: []
+      hand: []
+      deckPosition: {x: 0, y: 0}
+      spellDamageIncrease: 0
+      spellDamageCoefficient: 1
+    playerBlack:
+      soulOrbs: 0
+      soulEssence: 0
+      maxHandCardCount: 8
+      mulliganHandCount: 4
+      deck: []
+      hand: []
+      deckPosition: {x: 0, y: 0}
+      spellDamageIncrease: 0
+      spellDamageCoefficient: 1
+  playerColor: 0
+  chessBoard: {fileID: 2005263287}
+  cardBoard: {fileID: 518841780}
+  pieceInfo: {fileID: 1594983728884485668, guid: 6f09fd129a154794e8cebcd82ef9b00a, type: 3}
+  myDeckObject: {fileID: 1840355138}
+  whiteController: {fileID: 96209570}
+  isShowingPieceInfo: 0
+--- !u!4 &1683396309
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1683396307}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2005263286}
+  - {fileID: 1840355142}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1683396310
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1683396307}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -28864343
+  m_SortingLayer: 1
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 3c4d4249f89779042a2b8f1e58861488, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1001 &1835591131
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: coordinate.y
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_Name
+      value: BlackPawn (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+--- !u!4 &1835591132 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+  m_PrefabInstance: {fileID: 1835591131}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1840355138
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1840355142}
+  - component: {fileID: 1840355141}
+  - component: {fileID: 1840355140}
+  - component: {fileID: 1840355139}
+  m_Layer: 0
+  m_Name: DeckObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!210 &1840355139
+SortingGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840355138}
+  m_Enabled: 1
+  m_SortingLayerID: -1209845637
+  m_SortingLayer: 7
+  m_SortingOrder: 0
+  m_SortAtRoot: 0
+--- !u!61 &1840355140
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840355138}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2.34375, y: 3.3613281}
+  m_EdgeRadius: 0
+--- !u!114 &1840355141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840355138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e54dbdd387f0f5243a36c206b464edbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  deckCountText: {fileID: 905005323}
+--- !u!4 &1840355142
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1840355138}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 8, y: -1.9, z: 0}
+  m_LocalScale: {x: 0.8000001, y: 0.8000001, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 905005325}
+  m_Father: {fileID: 1683396309}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1845161347
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: coordinate.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_Name
+      value: WhitePawn (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+--- !u!4 &1845161348 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
+  m_PrefabInstance: {fileID: 1845161347}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1859173219
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1649245420}
+    m_Modifications:
+    - target: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: playerColor
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8799467538424568598, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      propertyPath: m_Name
+      value: BlackSoulOrb
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3176916607182412570, guid: 6c164027602fd41459ade190044e02be, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 6c164027602fd41459ade190044e02be, type: 3}
+--- !u!114 &1859173220 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 1859173219}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c371e07879a45944b455a0d95866948, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1859173221 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
+  m_PrefabInstance: {fileID: 1859173219}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1867634039
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2005263286}
+    m_Modifications:
+    - target: {fileID: -7555415609088345023, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: -7555415609088345023, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: coordinate.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 791631163023233955, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_Name
+      value: WhiteRook (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5606874248494239254, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: coordinate.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+--- !u!4 &1867634040 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
+  m_PrefabInstance: {fileID: 1867634039}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2005263285
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1683396309}
     m_Modifications:
     - target: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       propertyPath: m_LocalPosition.x
@@ -252,111 +3881,111 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1270185504}
+      addedObject: {fileID: 177257576}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 292124173}
+      addedObject: {fileID: 1255084450}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1930181716}
+      addedObject: {fileID: 245704526}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1896302724}
+      addedObject: {fileID: 903415351}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1189317795}
+      addedObject: {fileID: 1422035893}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 601369598}
+      addedObject: {fileID: 2015854898}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 156334868}
+      addedObject: {fileID: 214360097}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1932037987}
+      addedObject: {fileID: 1867634040}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1693464026}
+      addedObject: {fileID: 1433347278}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 951206455}
+      addedObject: {fileID: 607782381}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1049133438}
+      addedObject: {fileID: 2102641906}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1065683277}
+      addedObject: {fileID: 1207938937}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 237651592}
+      addedObject: {fileID: 476952872}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2113894515}
+      addedObject: {fileID: 1283634762}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 286397379}
+      addedObject: {fileID: 1845161348}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1889018079}
+      addedObject: {fileID: 917355679}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 274493262}
+      addedObject: {fileID: 1479606728}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1506195707}
+      addedObject: {fileID: 396808171}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 689507914}
+      addedObject: {fileID: 1502630788}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1059840498}
+      addedObject: {fileID: 1586896028}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 296427281}
+      addedObject: {fileID: 473590878}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 265288717}
+      addedObject: {fileID: 1619386277}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 872698882}
+      addedObject: {fileID: 1248443664}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2033906327}
+      addedObject: {fileID: 1090551261}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1366941806}
+      addedObject: {fileID: 1114100886}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 155604676}
+      addedObject: {fileID: 1835591132}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1302338171}
+      addedObject: {fileID: 754246362}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 515300280}
+      addedObject: {fileID: 1430963649}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1474420951}
+      addedObject: {fileID: 805565552}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 689813483}
+      addedObject: {fileID: 1533233092}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 947746573}
+      addedObject: {fileID: 1343568475}
     - targetCorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1348677539}
+      addedObject: {fileID: 1224059685}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
---- !u!4 &4027579 stripped
+--- !u!4 &2005263286 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1822202645157409802, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
-  m_PrefabInstance: {fileID: 4027578}
+  m_PrefabInstance: {fileID: 2005263285}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &4027580 stripped
+--- !u!114 &2005263287 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5739378138855264178, guid: c65f942ac20480445ad2c21134faa5ea, type: 3}
-  m_PrefabInstance: {fileID: 4027578}
+  m_PrefabInstance: {fileID: 2005263285}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -364,1144 +3993,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 29c32a2439bfc6941956521df1088098, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &84976150
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 84976152}
-  - component: {fileID: 84976151}
-  m_Layer: 0
-  m_Name: DeckTester
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &84976151
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 84976150}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 99a5ecd33958b4d479d5c003aaf93576, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  CardBoard: {fileID: 141907799}
-  gameBoard: {fileID: 369323391}
-  hand:
-  - {fileID: 9197931309180194723, guid: 55eea7fd0a8d7774b93722e3411c3f32, type: 3}
-  deck:
-  - {fileID: 4824830457768495894, guid: dc0e4c5991c664d4aaaad1229ca79999, type: 3}
-  - {fileID: -2815551797691118998, guid: 2d9947a9ca0af554ebef3f3b895f3d78, type: 3}
-  - {fileID: 3604200065000529882, guid: 69c628af0606ded408e60e35428eab89, type: 3}
-  - {fileID: 599667399022218461, guid: ff82128eca4e7994fb3e11360893a803, type: 3}
-  - {fileID: 90797455826848939, guid: fc33ddca6bc40df4db6a584de32b9753, type: 3}
---- !u!4 &84976152
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 84976150}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.57287, y: -2.0774097, z: -0.014950933}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &121223025
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 121223027}
-  - component: {fileID: 121223026}
-  m_Layer: 0
-  m_Name: WhitePlayerController
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &121223026
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 121223025}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1eac50d157602604689f8edef6de9a87, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  playerColor: 0
-  gameBoard: {fileID: 369323391}
-  soulOrb: {fileID: 314654283}
-  isUsingCard: 0
---- !u!4 &121223027
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 121223025}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.048588753, y: -0.10904288, z: -0.003311988}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1220735756}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &141907799
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 141907801}
-  - component: {fileID: 141907800}
-  m_Layer: 0
-  m_Name: CardBoard
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &141907800
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 141907799}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1733247665
-  m_SortingLayer: 4
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 560c1f21b8beb5b48be8d9bc129efede, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &141907801
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 141907799}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -5.8, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &155604675
+--- !u!1001 &2015854897
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &155604676 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 155604675}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &156334867
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -4506486621274620446, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -4506486621274620446, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: coordinate.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 200357043479895921, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_Name
-      value: WhiteKnight (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 36266483366b90e418695571e078f9f5, type: 3}
---- !u!4 &156334868 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 36266483366b90e418695571e078f9f5, type: 3}
-  m_PrefabInstance: {fileID: 156334867}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &237651591
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_Name
-      value: WhitePawn (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &237651592 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 237651591}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &265288716
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5347852299346591580, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_Name
-      value: BlackBishop (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 762e806020df41b488cb109713e1642f, type: 3}
---- !u!4 &265288717 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 762e806020df41b488cb109713e1642f, type: 3}
-  m_PrefabInstance: {fileID: 265288716}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &274493261
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 791631163023233955, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_Name
-      value: BlackRook
-      objectReference: {fileID: 0}
-    - target: {fileID: 5606874248494239254, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8771360765114331950, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
---- !u!4 &274493262 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-  m_PrefabInstance: {fileID: 274493261}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &286397378
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_Name
-      value: WhitePawn (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &286397379 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 286397378}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &292124172
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -4506486621274620446, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 200357043479895921, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_Name
-      value: WhiteKnight
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 36266483366b90e418695571e078f9f5, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 36266483366b90e418695571e078f9f5, type: 3}
---- !u!4 &292124173 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 36266483366b90e418695571e078f9f5, type: 3}
-  m_PrefabInstance: {fileID: 292124172}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &296427280
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 791631163023233955, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_Name
-      value: BlackKing
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6404625500466290932, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 6404625500466290932, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421589679604356431, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421589679604356431, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
---- !u!4 &296427281 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: c6261374f88bbbe4fac447df74d5e733, type: 3}
-  m_PrefabInstance: {fileID: 296427280}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &314654282
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1220735756}
-    m_Modifications:
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -4.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8799467538424568598, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_Name
-      value: WhiteSoulOrb
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3176916607182412570, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 6c164027602fd41459ade190044e02be, type: 3}
---- !u!114 &314654283 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
-  m_PrefabInstance: {fileID: 314654282}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c371e07879a45944b455a0d95866948, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &314654284 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-  m_PrefabInstance: {fileID: 314654282}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &369323390
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 369323392}
-  - component: {fileID: 369323393}
-  - component: {fileID: 369323391}
-  m_Layer: 0
-  m_Name: GameBoard
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &369323391
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 369323390}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9b1464a3476d9b6409b3f459335d71c1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  gameData:
-    pieceObjects: []
-    graveyard: []
-    playerWhite:
-      soulOrbs: 0
-      soulEssence: 0
-      maxHandCardCount: 8
-      mulliganHandCount: 4
-      deck: []
-      hand: []
-      deckPosition: {x: 0, y: 0}
-      spellDamageIncrease: 0
-      spellDamageCoefficient: 1
-    playerBlack:
-      soulOrbs: 0
-      soulEssence: 0
-      maxHandCardCount: 8
-      mulliganHandCount: 4
-      deck: []
-      hand: []
-      deckPosition: {x: 0, y: 0}
-      spellDamageIncrease: 0
-      spellDamageCoefficient: 1
-  playerColor: 0
-  chessBoard: {fileID: 4027580}
-  cardBoard: {fileID: 141907799}
-  pieceInfo: {fileID: 1594983728884485668, guid: 6f09fd129a154794e8cebcd82ef9b00a, type: 3}
-  myDeckObject: {fileID: 686238089}
-  whiteController: {fileID: 121223026}
-  isShowingPieceInfo: 0
---- !u!4 &369323392
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 369323390}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4027579}
-  - {fileID: 686238093}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &369323393
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 369323390}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -28864343
-  m_SortingLayer: 1
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 3c4d4249f89779042a2b8f1e58861488, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1001 &515300279
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &515300280 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 515300279}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &601369597
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
+    m_TransformParent: {fileID: 2005263286}
     m_Modifications:
     - target: {fileID: -2627985642760532060, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
       propertyPath: coordinate.x
@@ -1570,543 +4068,18 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
---- !u!4 &601369598 stripped
+--- !u!4 &2015854898 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-  m_PrefabInstance: {fileID: 601369597}
+  m_PrefabInstance: {fileID: 2015854897}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &686238089
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 686238093}
-  - component: {fileID: 686238092}
-  - component: {fileID: 686238091}
-  - component: {fileID: 686238090}
-  m_Layer: 0
-  m_Name: DeckObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!210 &686238090
-SortingGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 686238089}
-  m_Enabled: 1
-  m_SortingLayerID: -1209845637
-  m_SortingLayer: 7
-  m_SortingOrder: 0
-  m_SortAtRoot: 0
---- !u!61 &686238091
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 686238089}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 2.34375, y: 3.3613281}
-  m_EdgeRadius: 0
---- !u!114 &686238092
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 686238089}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e54dbdd387f0f5243a36c206b464edbb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  deckCountText: {fileID: 1133772940}
---- !u!4 &686238093
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 686238089}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 8, y: -1.9, z: 0}
-  m_LocalScale: {x: 0.8000001, y: 0.8000001, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1133772942}
-  m_Father: {fileID: 369323392}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &689507913
+--- !u!1001 &2102641905
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.x
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1115585259782103859, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5347852299346591580, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: m_Name
-      value: BlackBishop
-      objectReference: {fileID: 0}
-    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.x
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7382306160396615178, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 762e806020df41b488cb109713e1642f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 762e806020df41b488cb109713e1642f, type: 3}
---- !u!4 &689507914 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 762e806020df41b488cb109713e1642f, type: 3}
-  m_PrefabInstance: {fileID: 689507913}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &689813482
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &689813483 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 689813482}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &872698881
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_Name
-      value: BlackKnight (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
---- !u!4 &872698882 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-  m_PrefabInstance: {fileID: 872698881}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &947746572
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn (6)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &947746573 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 947746572}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &951206454
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_Name
-      value: WhitePawn (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &951206455 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 951206454}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1049133437
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
+    m_TransformParent: {fileID: 2005263286}
     m_Modifications:
     - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
       propertyPath: coordinate.x
@@ -2179,1928 +4152,19 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &1049133438 stripped
+--- !u!4 &2102641906 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 1049133437}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1059840497
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 791631163023233955, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_Name
-      value: BlackQueen
-      objectReference: {fileID: 0}
-    - target: {fileID: 1204250401167620467, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1204250401167620467, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 3805196673899827496, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3805196673899827496, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
---- !u!4 &1059840498 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: cfeabdd2fc986454886ecb9e16b1ce3c, type: 3}
-  m_PrefabInstance: {fileID: 1059840497}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1065683276
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_Name
-      value: WhitePawn (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &1065683277 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 1065683276}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1133772939
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1133772942}
-  - component: {fileID: 1133772941}
-  - component: {fileID: 1133772940}
-  m_Layer: 0
-  m_Name: DeckCountText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1133772940
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1133772939}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 10 cards left
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 3
-  m_fontSizeBase: 3
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 0
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
-  m_hasFontAssetChanged: 0
-  m_renderer: {fileID: 1133772941}
-  m_maskType: 0
---- !u!23 &1133772941
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1133772939}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1209845637
-  m_SortingLayer: 7
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!224 &1133772942
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1133772939}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 686238093}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -1.8}
-  m_SizeDelta: {x: 20, y: 5}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &1189317794
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -8797728076416791713, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: -8797728076416791713, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: coordinate.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_Name
-      value: WhiteKing
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421589679604356431, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
---- !u!4 &1189317795 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: b0abc6f3be8186e40ab93254c0fa29c6, type: 3}
-  m_PrefabInstance: {fileID: 1189317794}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1220735752
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1220735756}
-  - component: {fileID: 1220735755}
-  - component: {fileID: 1220735754}
-  - component: {fileID: 1220735753}
-  m_Layer: 0
-  m_Name: LocalController
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!61 &1220735753
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1220735752}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &1220735754
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1220735752}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b67f8aaf4ec06e5418ad0c5786a7c7ca, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  whiteButton: {fileID: 21300000, guid: 28d3e7d3d20d2004aa0289ff19cdcadb, type: 3}
-  blackButton: {fileID: 21300000, guid: edc8a02128854254da50760cf1530179, type: 3}
-  whiteController: {fileID: 121223026}
-  blackController: {fileID: 1488737758}
---- !u!212 &1220735755
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1220735752}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1733247665
-  m_SortingLayer: 4
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 28d3e7d3d20d2004aa0289ff19cdcadb, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1220735756
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1220735752}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8, y: 0, z: -0.035696927}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1488737759}
-  - {fileID: 121223027}
-  - {fileID: 1598306529}
-  - {fileID: 314654284}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1270185503
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 791631163023233955, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_Name
-      value: WhiteRook
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
---- !u!4 &1270185504 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-  m_PrefabInstance: {fileID: 1270185503}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1302338170
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &1302338171 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 1302338170}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1339561635
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1339561636}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1339561636
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1339561635}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.1299443, y: -1.4086864, z: -0.0017261512}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1348677538
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn (7)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &1348677539 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 1348677538}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1366941805
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &1366941806 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 1366941805}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1474420950
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: coordinate.y
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_Name
-      value: BlackPawn (4)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
---- !u!4 &1474420951 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
-  m_PrefabInstance: {fileID: 1474420950}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1488737757
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1488737759}
-  - component: {fileID: 1488737758}
-  m_Layer: 0
-  m_Name: BlackPlayerController
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1488737758
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488737757}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1eac50d157602604689f8edef6de9a87, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  playerColor: 1
-  gameBoard: {fileID: 369323391}
-  soulOrb: {fileID: 1598306528}
-  isUsingCard: 0
---- !u!4 &1488737759
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488737757}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.048588753, y: -0.10904288, z: -0.003311988}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1220735756}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1506195706
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 200357043479895921, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_Name
-      value: BlackKnight
-      objectReference: {fileID: 0}
-    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3287479800442724811, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
---- !u!4 &1506195707 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: b83aeec66bb7f2140832860720c8fb22, type: 3}
-  m_PrefabInstance: {fileID: 1506195706}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1598306527
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1220735756}
-    m_Modifications:
-    - target: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: playerColor
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 4.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8799467538424568598, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      propertyPath: m_Name
-      value: BlackSoulOrb
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3176916607182412570, guid: 6c164027602fd41459ade190044e02be, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 6c164027602fd41459ade190044e02be, type: 3}
---- !u!114 &1598306528 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -6293375645755760837, guid: 6c164027602fd41459ade190044e02be, type: 3}
-  m_PrefabInstance: {fileID: 1598306527}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c371e07879a45944b455a0d95866948, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1598306529 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 691786838047155631, guid: 6c164027602fd41459ade190044e02be, type: 3}
-  m_PrefabInstance: {fileID: 1598306527}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1693464025
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_Name
-      value: WhitePawn
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &1693464026 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 1693464025}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1889018078
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_Name
-      value: WhitePawn (7)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &1889018079 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 1889018078}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1896302723
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 791631163023233955, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_Name
-      value: WhiteQueen
-      objectReference: {fileID: 0}
-    - target: {fileID: 1204250401167620467, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4662516292740937369, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: coordinate.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4662516292740937369, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: coordinate.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
---- !u!4 &1896302724 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 2324b7b728002004396758dc0c5e88ad, type: 3}
-  m_PrefabInstance: {fileID: 1896302723}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1930181715
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -2627985642760532060, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: coordinate.x
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 908871237961613479, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1115585259782103859, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: coordinate.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5347852299346591580, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      propertyPath: m_Name
-      value: WhiteBishop
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
---- !u!4 &1930181716 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 81108007b7693784cbb4bbd1c98e35d9, type: 3}
-  m_PrefabInstance: {fileID: 1930181715}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1932037986
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -7555415609088345023, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: -7555415609088345023, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: coordinate.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_Name
-      value: WhiteRook (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5606874248494239254, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
---- !u!4 &1932037987 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: c4afb63608ae3f646b0f65ff69a3cec6, type: 3}
-  m_PrefabInstance: {fileID: 1932037986}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1970317165
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1970317169}
-  - component: {fileID: 1970317168}
-  - component: {fileID: 1970317167}
-  - component: {fileID: 1970317166}
-  m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1970317166
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1970317165}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    m_Quality: 3
-    m_FrameInfluence: 0.1
-    m_JitterScale: 1
-    m_MipBias: 0
-    m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
---- !u!81 &1970317167
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1970317165}
-  m_Enabled: 1
---- !u!20 &1970317168
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1970317165}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 1
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &1970317169
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1970317165}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &2033906326
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: 791631163023233955, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_Name
-      value: BlackRook (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5606874248494239254, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5606874248494239254, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8771360765114331950, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: coordinate.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 8771360765114331950, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      propertyPath: coordinate.y
-      value: 7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
---- !u!4 &2033906327 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 2148801fa57205644be7a267c7bd5a71, type: 3}
-  m_PrefabInstance: {fileID: 2033906326}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2113894514
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4027579}
-    m_Modifications:
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: -6858769460858049831, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: -460640652567856469, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: coordinate.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 791631163023233955, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_Name
-      value: WhitePawn (5)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5954609769523367539, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3809511900624011511, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3562893191139021320, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
---- !u!4 &2113894515 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3942774322492686617, guid: 72a9fbc4160515844976c18efb43c442, type: 3}
-  m_PrefabInstance: {fileID: 2113894514}
+  m_PrefabInstance: {fileID: 2102641905}
   m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 141907801}
-  - {fileID: 84976152}
-  - {fileID: 1339561636}
-  - {fileID: 1970317169}
-  - {fileID: 369323392}
-  - {fileID: 1220735756}
+  - {fileID: 518841782}
+  - {fileID: 1323045556}
+  - {fileID: 726723708}
+  - {fileID: 1540373070}
+  - {fileID: 1683396309}
+  - {fileID: 1649245420}
+  - {fileID: 421155004}

--- a/Assets/Scenes/TestScenes/GameScene_WKH.unity
+++ b/Assets/Scenes/TestScenes/GameScene_WKH.unity
@@ -155,7 +155,7 @@ MonoBehaviour:
   gameBoard: {fileID: 1683396308}
   soulOrb: {fileID: 1354575176}
   isUsingCard: 0
-  isMyTurn: 1
+  _isMyTurn: 0
 --- !u!4 &96209571
 Transform:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   gameBoard: {fileID: 1683396308}
   soulOrb: {fileID: 1859173220}
   isUsingCard: 0
-  isMyTurn: 0
+  _isMyTurn: 0
 --- !u!4 &211787240
 Transform:
   m_ObjectHideFlags: 0
@@ -1556,6 +1556,14 @@ PrefabInstance:
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: _maxHP
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
+      propertyPath: attackDamage
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: -179862710205357861, guid: 5774fd488f14e6b4396382217fb55d10, type: 3}
       propertyPath: coordinate.y
       value: 6
       objectReference: {fileID: 0}
@@ -2063,13 +2071,15 @@ MonoBehaviour:
   CardBoard: {fileID: 518841780}
   gameBoard: {fileID: 1683396308}
   hand:
-  - {fileID: 7433252666421529211, guid: fc310b2ab5a30de4298b4aea18a015f4, type: 3}
-  - {fileID: 1292469394887977406, guid: 69acd9f53abcc974da0de5adf88dba59, type: 3}
+  - {fileID: -542098215232420279, guid: a624a3c6dfec07e4e96e01a10fa19a1d, type: 3}
+  - {fileID: -2815551797691118998, guid: 2d9947a9ca0af554ebef3f3b895f3d78, type: 3}
   deck:
   - {fileID: 4824830457768495894, guid: dc0e4c5991c664d4aaaad1229ca79999, type: 3}
-  - {fileID: -2815551797691118998, guid: 2d9947a9ca0af554ebef3f3b895f3d78, type: 3}
-  - {fileID: 3604200065000529882, guid: 69c628af0606ded408e60e35428eab89, type: 3}
+  - {fileID: 6842244014742130878, guid: ce404b57a1b095e4bbcfbec40f372c12, type: 3}
+  - {fileID: 6592858290932310892, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
   - {fileID: 599667399022218461, guid: ff82128eca4e7994fb3e11360893a803, type: 3}
+  - {fileID: -1208510047847783411, guid: 97d03e24daf82ae4486ae6ceec8dfdeb, type: 3}
+  - {fileID: 7433252666421529211, guid: fc310b2ab5a30de4298b4aea18a015f4, type: 3}
 --- !u!4 &1323045556
 Transform:
   m_ObjectHideFlags: 0
@@ -3247,7 +3257,8 @@ MonoBehaviour:
   cardBoard: {fileID: 518841780}
   pieceInfo: {fileID: 1594983728884485668, guid: 6f09fd129a154794e8cebcd82ef9b00a, type: 3}
   myDeckObject: {fileID: 1840355138}
-  whiteController: {fileID: 96209570}
+  myController: {fileID: 96209570}
+  opponentController: {fileID: 211787239}
   isShowingPieceInfo: 0
 --- !u!4 &1683396309
 Transform:

--- a/Assets/Script/Game/Card/Cards/Greek/Perseus.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/Perseus.cs
@@ -65,5 +65,15 @@ public class Perseus : SoulCard
     private void StunChessPiece(ChessPiece chessPiece)
     {
         // 구현 필요
-    } 
+    }
+
+    public override void AddEffect()
+    {
+
+    }
+
+    public override void RemoveEffect()
+    {
+
+    }
 }

--- a/Assets/Script/Game/Card/Cards/Greek/Poseidon.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/Poseidon.cs
@@ -8,7 +8,7 @@ public class Poseidon : SoulCard
     protected override void Awake()
     {
         base.Awake();
-        gameObject.GetComponent<SoulCard>().OnInfuse += SoulEffect;
+        OnInfuse += SoulEffect;
     }
 
     public void SoulEffect(ChessPiece chessPiece)

--- a/Assets/Script/Game/Card/Cards/Greek/Poseidon.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/Poseidon.cs
@@ -22,4 +22,14 @@ public class Poseidon : SoulCard
             }
         }
     }
+
+    public override void AddEffect()
+    {
+
+    }
+
+    public override void RemoveEffect()
+    {
+
+    }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
@@ -8,9 +8,16 @@ public class Fenrir : SoulCard
     private int IncreaseAmountAD = 20;
     private int IncreaseAmountHP = 20;
 
+    private int buffedAD;
+    private int buffedHP;
+
     protected override void Awake()
     {
         base.Awake();
+
+        buffedAD = 0;
+        buffedHP = 0;
+
         OnInfuse += (ChessPiece chessPiece) => chessPiece.OnKill += IncreaseStat;
         OnInfuse += (ChessPiece chessPiece) => chessPiece.OnSoulRemoved += RemoveEffect;
     }
@@ -19,10 +26,16 @@ public class Fenrir : SoulCard
     {
         InfusedPiece.AD += IncreaseAmountAD;
         InfusedPiece.maxHP += IncreaseAmountHP;
+
+        buffedAD += IncreaseAmountAD;
+        buffedHP += IncreaseAmountHP;
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
+        InfusedPiece.maxHP -= buffedHP;
+        InfusedPiece.AD -= buffedAD;
+
         InfusedPiece.OnKill -= IncreaseStat;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
@@ -31,6 +31,14 @@ public class Fenrir : SoulCard
         buffedHP += IncreaseAmountHP;
     }
 
+    public override void AddEffect()
+    {
+        InfusedPiece.maxHP += buffedHP;
+        InfusedPiece.AD += buffedAD;
+
+        InfusedPiece.OnKill += IncreaseStat;
+    }
+
     public override void RemoveEffect()
     {
         InfusedPiece.maxHP -= buffedHP;

--- a/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
@@ -12,11 +12,17 @@ public class Fenrir : SoulCard
     {
         base.Awake();
         OnInfuse += (ChessPiece chessPiece) => chessPiece.OnKill += IncreaseStat;
+        OnInfuse += (ChessPiece chessPiece) => chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
     private void IncreaseStat(ChessPiece chessPiece)
     {
         InfusedPiece.AD += IncreaseAmountAD;
         InfusedPiece.maxHP += IncreaseAmountHP;
+    }
+
+    private void RemoveEffect()
+    {
+        InfusedPiece.OnKill -= IncreaseStat;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Frigg.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Frigg.cs
@@ -7,12 +7,17 @@ public class Frigg : SoulCard
 {
     public int decreaseAmount = 20;
 
+    private Dictionary<ChessPiece, int> decreaseAmountDictionary;
+
     protected override void Awake()
     {
         base.Awake();
+
+        decreaseAmountDictionary = new();
         OnInfuse += (ChessPiece chessPiece) => DecreaseEnemyPiecesAD();
-        OnInfuse += (ChessPiece chessPiece) => GameBoard.instance.myController.OnOpponentTurnEnd += DecreaseEnemyPiecesAD;
+        OnInfuse += (ChessPiece chessPiece) => GameBoard.instance.myController.OnMyTurnStart += DecreaseEnemyPiecesAD;
         OnInfuse += (ChessPiece chessPiece) => GameBoard.instance.myController.OnMyTurnEnd += IncreaseEnemyPiecesAD;
+        OnInfuse += (ChessPiece chessPiece) => chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
     private void IncreaseEnemyPiecesAD()
@@ -21,7 +26,14 @@ public class Frigg : SoulCard
 
         foreach (ChessPiece piece in enemyPieceList)
         {
-            piece.AD += decreaseAmount;
+            if (decreaseAmountDictionary.ContainsKey(piece))
+            {
+                piece.AD += decreaseAmountDictionary[piece];
+            }
+            else
+            {
+                piece.AD += decreaseAmount;
+            }
         }
     }
 
@@ -29,9 +41,23 @@ public class Frigg : SoulCard
     {
         List<ChessPiece> enemyPieceList = GameBoard.instance.gameData.pieceObjects.Where(piece => piece.pieceColor != GameBoard.instance.myController.playerColor).ToList();
 
+        decreaseAmountDictionary.Clear();
         foreach (ChessPiece piece in enemyPieceList)
         {
+            if (piece.AD < decreaseAmount)
+            {
+                decreaseAmountDictionary.TryAdd(piece, piece.AD);
+            }
+
             piece.AD -= decreaseAmount;
         }
+    }
+
+    private void RemoveEffect()
+    {
+        IncreaseEnemyPiecesAD();
+        GameBoard.instance.myController.OnMyTurnStart -= DecreaseEnemyPiecesAD;
+        GameBoard.instance.myController.OnMyTurnEnd -= IncreaseEnemyPiecesAD;
+        decreaseAmountDictionary.Clear();
     }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Frigg.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Frigg.cs
@@ -53,6 +53,13 @@ public class Frigg : SoulCard
         }
     }
 
+    public override void AddEffect()
+    {
+        DecreaseEnemyPiecesAD();
+        GameBoard.instance.myController.OnMyTurnStart += DecreaseEnemyPiecesAD;
+        GameBoard.instance.myController.OnMyTurnEnd += IncreaseEnemyPiecesAD;
+    }
+
     public override void RemoveEffect()
     {
         IncreaseEnemyPiecesAD();

--- a/Assets/Script/Game/Card/Cards/Norse/Frigg.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Frigg.cs
@@ -53,7 +53,7 @@ public class Frigg : SoulCard
         }
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         IncreaseEnemyPiecesAD();
         GameBoard.instance.myController.OnMyTurnStart -= DecreaseEnemyPiecesAD;

--- a/Assets/Script/Game/Card/Cards/Norse/MotherBear.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/MotherBear.cs
@@ -4,5 +4,13 @@ using UnityEngine;
 
 public class MotherBear : SoulCard
 {
-    
+    public override void AddEffect()
+    {
+
+    }
+
+    public override void RemoveEffect()
+    {
+
+    }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Odin.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Odin.cs
@@ -41,4 +41,14 @@ public class Odin : SoulCard
         selectedCard.isInSelection = false;
         GameBoard.instance.gameData.playerWhite.TryAddCardInHand(selectedCard);
     }
+
+    public override void AddEffect()
+    {
+
+    }
+
+    public override void RemoveEffect()
+    {
+
+    }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Surtr.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Surtr.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,31 +9,48 @@ public class Surtr : SoulCard
     protected override void Awake()
     {
         base.Awake();
-        // �ڽ�Ʈ ����: ī�� ���� �ñ⿡ ���� �޶��� �ʿ� ����
-        GameBoard.instance.myController.OnMyTurnEnd += DecreaseCost;
 
-        OnInfuse += (chessPiece) => GameBoard.instance.myController.OnMyTurnEnd -= DecreaseCost;
+        GameBoard.instance.myController.OnMyTurnEnd += DecreaseCost;
+        GameBoard.instance.opponentController.OnMyTurnEnd += DecreaseCost;
+
+        OnInfuse += (ChessPiece chessPiece) => GameBoard.instance.myController.OnMyTurnEnd -= DecreaseCost;
+        OnInfuse += (ChessPiece chessPiece) => GameBoard.instance.opponentController.OnMyTurnEnd -= DecreaseCost;
+
         OnInfuse += DestroyAllCards;
-        OnInfuse += (chessPiece) => GameBoard.instance.myController.OnMyTurnEnd += DestroyInfusedPiece;
+        OnInfuse += (ChessPiece chessPiece) => GameBoard.instance.myController.OnMyTurnEnd += DestroyInfusedPiece;
+
+        OnInfuse += (ChessPiece chessPiece) => chessPiece.OnSoulRemoved += RemoveEffect;
+    }
+
+    private void OnDisable()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd -= DecreaseCost;
+        GameBoard.instance.opponentController.OnMyTurnEnd -= DecreaseCost;
     }
 
     private void DecreaseCost()
     {
-        cost--;
+        if (cost > 0)
+        {
+            cost--;
+        }
     }
 
     private void DestroyAllCards(ChessPiece chessPiece)
     {
-        GameBoard.instance.gameData.playerWhite.hand.Clear();
-        GameBoard.instance.gameData.playerWhite.deck.Clear();
-        GameBoard.instance.gameData.playerBlack.hand.Clear();
-        GameBoard.instance.gameData.playerBlack.deck.Clear();
-
-        // Instantiate�� ī�嵵 ���� �ʿ�
+        GameBoard.instance.gameData.playerWhite.RemoveHandCards();
+        GameBoard.instance.gameData.playerWhite.RemoveDeckCards();
+        GameBoard.instance.gameData.playerBlack.RemoveHandCards();
+        GameBoard.instance.gameData.playerBlack.RemoveDeckCards();
     }
 
     private void DestroyInfusedPiece()
     {
         InfusedPiece.Kill();
+    }
+
+    private void RemoveEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd -= DestroyInfusedPiece;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Surtr.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Surtr.cs
@@ -49,7 +49,7 @@ public class Surtr : SoulCard
         InfusedPiece.Kill();
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= DestroyInfusedPiece;
     }

--- a/Assets/Script/Game/Card/Cards/Norse/Surtr.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Surtr.cs
@@ -49,6 +49,10 @@ public class Surtr : SoulCard
         InfusedPiece.Kill();
     }
 
+    public override void AddEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd += DestroyInfusedPiece;
+    }
     public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= DestroyInfusedPiece;

--- a/Assets/Script/Game/Card/Cards/Norse/Thor.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Thor.cs
@@ -22,6 +22,11 @@ public class Thor : SoulCard
         enemyPieceList[Random.Range(0, enemyPieceList.Count)].HP -= InfusedPiece.AD;
     }
 
+    public override void AddEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd += AttackRandomEnemyPiece;
+    }
+
     public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= AttackRandomEnemyPiece;

--- a/Assets/Script/Game/Card/Cards/Norse/Thor.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Thor.cs
@@ -9,6 +9,7 @@ public class Thor : SoulCard
     {
         base.Awake();
         OnInfuse += (ChessPiece chessPiece) => GameBoard.instance.myController.OnMyTurnEnd += AttackRandomEnemyPiece;
+        OnInfuse += (ChessPiece chessPiece) => chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
     private void AttackRandomEnemyPiece()
@@ -19,5 +20,10 @@ public class Thor : SoulCard
             return;
 
         enemyPieceList[Random.Range(0, enemyPieceList.Count)].HP -= InfusedPiece.AD;
+    }
+
+    private void RemoveEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd -= AttackRandomEnemyPiece;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Thor.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Thor.cs
@@ -22,7 +22,7 @@ public class Thor : SoulCard
         enemyPieceList[Random.Range(0, enemyPieceList.Count)].HP -= InfusedPiece.AD;
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= AttackRandomEnemyPiece;
     }

--- a/Assets/Script/Game/Card/Cards/Western/Abel.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Abel.cs
@@ -35,7 +35,7 @@ public class Abel : SoulCard
         }
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         InfusedPiece.OnAttacked -= OnAttackedEffect;
         InfusedPiece.OnKilled -= OnKilledEffect;

--- a/Assets/Script/Game/Card/Cards/Western/Abel.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Abel.cs
@@ -35,6 +35,12 @@ public class Abel : SoulCard
         }
     }
 
+    public override void AddEffect()
+    {
+        InfusedPiece.OnAttacked += OnAttackedEffect;
+        InfusedPiece.OnKilled += OnKilledEffect;
+    }
+
     public override void RemoveEffect()
     {
         InfusedPiece.OnAttacked -= OnAttackedEffect;

--- a/Assets/Script/Game/Card/Cards/Western/Abel.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Abel.cs
@@ -7,30 +7,19 @@ using UnityEngine;
 public class Abel : SoulCard
 {
     ChessPiece recent;
-    private bool myturn = true;
 
     protected override void Awake()
     {
         base.Awake();
-        gameObject.GetComponent<SoulCard>().OnInfuse += InfuseEffect;
+        OnInfuse += InfuseEffect;
     }
 
     public void InfuseEffect(ChessPiece chessPiece)
     {
         chessPiece.OnAttacked += OnAttackedEffect;
-        chessPiece.OnKilled += OnkilledEffect;
-        GameBoard.instance.myController.OnMyDraw += MyTurnSignal;
-        GameBoard.instance.myController.OnMyTurnEnd += NotMyTurnSignal;
-    }
+        chessPiece.OnKilled += OnKilledEffect;
 
-    public void MyTurnSignal()
-    {
-        myturn = true;
-    }
-
-    public void NotMyTurnSignal()
-    {
-        myturn = false;
+        chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
     public void OnAttackedEffect(ChessPiece chessPiece, int damamge)
@@ -38,12 +27,17 @@ public class Abel : SoulCard
         recent = chessPiece;
     }
 
-    public void OnkilledEffect(ChessPiece chessPiece)
+    public void OnKilledEffect(ChessPiece chessPiece)
     {
-        if (myturn)
+        if (!GameBoard.instance.myController.isMyTurn)
         {
             recent.Kill();
         }
     }
 
+    private void RemoveEffect()
+    {
+        InfusedPiece.OnAttacked -= OnAttackedEffect;
+        InfusedPiece.OnKilled -= OnKilledEffect;
+    }
 }

--- a/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
@@ -32,7 +32,7 @@ public class Behemoth : SoulCard
         buffedAD += 10;
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         InfusedPiece.maxHP -= buffedHP;
         InfusedPiece.AD -= buffedAD;

--- a/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class Behemoth : SoulCard
 {
+    private int buffedHP;
+    private int buffedAD;
+
     protected override void Awake()
     {
         base.Awake();
@@ -12,12 +15,28 @@ public class Behemoth : SoulCard
 
     public void SoulEffect(ChessPiece chessPiece)
     {
-        GameBoard.instance.myController.OnMyTurnEnd += () => SoulEffect2(InfusedPiece);
+        buffedHP = 0;
+        buffedAD = 0;
+
+        GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
+
+        chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
-    public void SoulEffect2(ChessPiece piece)
+    public void SoulEffect2()
     {
-        HP += 10;
-        AD += 10;
+        InfusedPiece.maxHP += 10;
+        InfusedPiece.AD += 10;
+
+        buffedHP += 10;
+        buffedAD += 10;
+    }
+
+    private void RemoveEffect()
+    {
+        InfusedPiece.maxHP -= buffedHP;
+        InfusedPiece.AD -= buffedAD;
+
+        GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
@@ -32,6 +32,14 @@ public class Behemoth : SoulCard
         buffedAD += 10;
     }
 
+    public override void AddEffect()
+    {
+        InfusedPiece.maxHP += buffedHP;
+        InfusedPiece.AD += buffedAD;
+
+        GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
+    }
+
     public override void RemoveEffect()
     {
         InfusedPiece.maxHP -= buffedHP;

--- a/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
+++ b/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
@@ -10,13 +10,15 @@ public class DonQuixote : SoulCard
     protected override void Awake()
     {
         base.Awake();
-        gameObject.GetComponent<SoulCard>().OnInfuse += InfuseEffect;
+        OnInfuse += InfuseEffect;
     }
 
     public void InfuseEffect(ChessPiece chessPiece)
     {
         chessPiece.OnStartAttack += StartAttackEffect;
         chessPiece.OnEndAttack += EndAttackEffect;
+
+        chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
     public void StartAttackEffect(ChessPiece chessPiece)
@@ -35,5 +37,11 @@ public class DonQuixote : SoulCard
             this.InfusedPiece.AD -= extraAD;
             extraAttack = false;
         }
+    }
+
+    private void RemoveEffect()
+    {
+        InfusedPiece.OnStartAttack -= StartAttackEffect;
+        InfusedPiece.OnEndAttack -= EndAttackEffect;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
+++ b/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
@@ -39,6 +39,12 @@ public class DonQuixote : SoulCard
         }
     }
 
+    public override void AddEffect()
+    {
+        InfusedPiece.OnStartAttack += StartAttackEffect;
+        InfusedPiece.OnEndAttack += EndAttackEffect;
+    }
+
     public override void RemoveEffect()
     {
         InfusedPiece.OnStartAttack -= StartAttackEffect;

--- a/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
+++ b/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
@@ -39,7 +39,7 @@ public class DonQuixote : SoulCard
         }
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         InfusedPiece.OnStartAttack -= StartAttackEffect;
         InfusedPiece.OnEndAttack -= EndAttackEffect;

--- a/Assets/Script/Game/Card/Cards/Western/Kraken.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Kraken.cs
@@ -36,7 +36,7 @@ public class Kraken : SoulCard
         }
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         InfusedPiece.OnKilled -= OnKilledEffect;
     }

--- a/Assets/Script/Game/Card/Cards/Western/Kraken.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Kraken.cs
@@ -12,15 +12,17 @@ public class Kraken : SoulCard
     protected override void Awake()
     {
         base.Awake();
-        gameObject.GetComponent<SoulCard>().OnInfuse += InfuseEffect;
+        OnInfuse += InfuseEffect;
     }
 
     public void InfuseEffect(ChessPiece chessPiece)
     {
-        chessPiece.OnKilled += OnkilledEffect;
+        chessPiece.OnKilled += OnKilledEffect;
+
+        chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
-    public void OnkilledEffect(ChessPiece chessPiece)
+    public void OnKilledEffect(ChessPiece chessPiece)
     {
         List<ChessPiece> targets = GameBoard.instance.gameData.pieceObjects.Where(obj => obj.pieceColor != GameBoard.instance.myController.playerColor).ToList();
 
@@ -34,4 +36,8 @@ public class Kraken : SoulCard
         }
     }
 
+    private void RemoveEffect()
+    {
+        InfusedPiece.OnKilled -= OnKilledEffect;
+    }
 }

--- a/Assets/Script/Game/Card/Cards/Western/Kraken.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Kraken.cs
@@ -36,6 +36,11 @@ public class Kraken : SoulCard
         }
     }
 
+    public override void AddEffect()
+    {
+        InfusedPiece.OnKilled += OnKilledEffect;
+    }
+
     public override void RemoveEffect()
     {
         InfusedPiece.OnKilled -= OnKilledEffect;

--- a/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
+++ b/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
@@ -32,6 +32,11 @@ public class LadyOfTheLake : SoulCard
         pieceList[temp].AD += 20;
     }
 
+    public override void AddEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
+    }
+
     public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;

--- a/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
+++ b/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
@@ -32,7 +32,7 @@ public class LadyOfTheLake : SoulCard
         pieceList[temp].AD += 20;
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;
     }

--- a/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
+++ b/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
@@ -7,26 +7,33 @@ public class LadyOfTheLake : SoulCard
     protected override void Awake()
     {
         base.Awake();
-        gameObject.GetComponent<SoulCard>().OnInfuse += SoulEffect;
+        OnInfuse += SoulEffect;
     }
 
     public void SoulEffect(ChessPiece chessPiece)
     {
         //강림 시 OnMyTurnEnd에 함수 추가
-        GameBoard.instance.myController.OnMyTurnEnd += () => SoulEffect2(InfusedPiece);
+        GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
+
+        chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
-    public void SoulEffect2(ChessPiece piece) //턴 종료 시마다 호출될 텐데
+    public void SoulEffect2() //턴 종료 시마다 호출될 텐데
     {
         List<ChessPiece> pieceList = new List<ChessPiece>();
         for (int i = GameBoard.instance.gameData.pieceObjects.Count - 1; i >= 0; i--)
         {
-            if (GameBoard.instance.gameData.pieceObjects[i].pieceColor == piece.pieceColor)
+            if (GameBoard.instance.gameData.pieceObjects[i].pieceColor == GameBoard.instance.myController.playerColor)
                 pieceList.Add(GameBoard.instance.gameData.pieceObjects[i]);
         }
 
         int temp = Random.Range(0, pieceList.Count);
         pieceList[temp].maxHP += 20;
         pieceList[temp].AD += 20;
+    }
+
+    private void RemoveEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
+++ b/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
@@ -37,6 +37,10 @@ public class MorganLeFay : SoulCard
         }
     }
 
+    public override void AddEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
+    }
     public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;

--- a/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
+++ b/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
@@ -7,21 +7,23 @@ public class MorganLeFay : SoulCard
     protected override void Awake()
     {
         base.Awake();
-        gameObject.GetComponent<SoulCard>().OnInfuse += SoulEffect;
+        OnInfuse += SoulEffect;
     }
 
     public void SoulEffect(ChessPiece chessPiece)
     {
         //강림 시 OnMyTurnEnd에 함수 추가
-        GameBoard.instance.myController.OnMyTurnEnd += () => SoulEffect2(InfusedPiece);
+        GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
+
+        chessPiece.OnSoulRemoved += RemoveEffect;
     }
 
-    public void SoulEffect2(ChessPiece piece) //턴 종료 시마다 호출되는 함수인데
+    public void SoulEffect2() //턴 종료 시마다 호출되는 함수인데
     {
         List<ChessPiece> pieceList = new List<ChessPiece>();
         for (int i = GameBoard.instance.gameData.pieceObjects.Count - 1; i >= 0; i--)
         {
-            if (GameBoard.instance.gameData.pieceObjects[i].pieceColor == piece.pieceColor)
+            if (GameBoard.instance.gameData.pieceObjects[i].pieceColor == GameBoard.instance.myController.playerColor)
             {
                 //체력이 깎여있는 아군만 pieceList에 추가해서 그 중에서 무작위 회복
                 if (GameBoard.instance.gameData.pieceObjects[i].HP != GameBoard.instance.gameData.pieceObjects[i].maxHP)
@@ -33,5 +35,10 @@ public class MorganLeFay : SoulCard
             int temp = Random.Range(0, pieceList.Count);
             pieceList[temp].HP = pieceList[temp].maxHP;
         }
+    }
+
+    private void RemoveEffect()
+    {
+        GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
+++ b/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
@@ -37,7 +37,7 @@ public class MorganLeFay : SoulCard
         }
     }
 
-    private void RemoveEffect()
+    public override void RemoveEffect()
     {
         GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;
     }

--- a/Assets/Script/Game/Card/SoulCard.cs
+++ b/Assets/Script/Game/Card/SoulCard.cs
@@ -87,4 +87,9 @@ public class SoulCard : Card
         OnInfuse?.Invoke(targetPiece);
     }
 
+
+    public virtual void RemoveEffect()
+    {
+
+    }
 }

--- a/Assets/Script/Game/Card/SoulCard.cs
+++ b/Assets/Script/Game/Card/SoulCard.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using TMPro;
 using Unity.VisualScripting;
 using System.Linq;
-public class SoulCard : Card
+public abstract class SoulCard : Card
 {
     [Serializable]      // 하나의 PieceType에 하나의 Sprite가 선택되도록 설정되어야 함
     private struct AccessorySprite
@@ -87,13 +87,7 @@ public class SoulCard : Card
         OnInfuse?.Invoke(targetPiece);
     }
 
-    public virtual void AddEffect()
-    {
+    public abstract void AddEffect();
 
-    }
-
-    public virtual void RemoveEffect()
-    {
-
-    }
+    public abstract void RemoveEffect();
 }

--- a/Assets/Script/Game/Card/SoulCard.cs
+++ b/Assets/Script/Game/Card/SoulCard.cs
@@ -87,6 +87,10 @@ public class SoulCard : Card
         OnInfuse?.Invoke(targetPiece);
     }
 
+    public virtual void AddEffect()
+    {
+
+    }
 
     public virtual void RemoveEffect()
     {

--- a/Assets/Script/Game/ChessPieces/ChessPiece.cs
+++ b/Assets/Script/Game/ChessPieces/ChessPiece.cs
@@ -97,6 +97,8 @@ abstract public class ChessPiece : TargetableObject
     //public Action OnGetMovableCoordinate;
     public Action<Vector2Int> OnMove;
 
+    public Action OnSoulRemoved;
+
     private void Awake()
     {
         _currentHP = _maxHP;
@@ -173,6 +175,7 @@ abstract public class ChessPiece : TargetableObject
     public void Kill()
     {
         OnKilled?.Invoke(this);
+        RemoveSoul();
 
         isAlive = false;
         pieceObject.HPText.text = "0";
@@ -205,6 +208,9 @@ abstract public class ChessPiece : TargetableObject
         AD -= soul.AD;
 
         spriteRenderer.sprite = defaultSprite;
+
+        OnSoulRemoved?.Invoke();
+        OnSoulRemoved = null;
 
         Destroy(soul);
         soul = null;

--- a/Assets/Script/Game/GameBoard.cs
+++ b/Assets/Script/Game/GameBoard.cs
@@ -21,6 +21,8 @@ public class GameBoard : MonoBehaviour
     public PlayerController myController;
     public PlayerController opponentController;
 
+    public Action<ChessPiece> OnPieceKilled;
+
     public bool isActivePlayer
     {
         get => myController.enabled;
@@ -63,6 +65,8 @@ public class GameBoard : MonoBehaviour
     }
     public void KillPiece(ChessPiece targetPiece)
     {
+        OnPieceKilled?.Invoke(targetPiece);
+
         gameData.graveyard.Add(targetPiece);
         gameData.pieceObjects.Remove(targetPiece);
 

--- a/Assets/Script/Game/PlayerController.cs
+++ b/Assets/Script/Game/PlayerController.cs
@@ -19,10 +19,17 @@ public class PlayerController : MonoBehaviour
     public bool isUsingCard = false;
     List<TargetableObject> targetableObjects = new List<TargetableObject>();
 
+    public Action OnMyTurnStart;
+    public Action OnOpponentTurnStart;
+
     public Action OnMyDraw;
-    //    public Action OnOpponentDraw;
+    public Action OnOpponentDraw;
+
     public Action OnMyTurnEnd;
     public Action OnOpponentTurnEnd;
+
+    [SerializeField] private bool _isMyTurn;
+    public bool isMyTurn { get => _isMyTurn; }
 
     private void OnEnable()
     {
@@ -212,14 +219,36 @@ public class PlayerController : MonoBehaviour
 
         GameBoard.instance.HideCard();
     }
-    /// <summary>
-    ///     아직 구현 안됐습니다.
-    /// </summary>
+
+    public void TurnStart()
+    {
+        _isMyTurn = true;
+        OnMyTurnStart?.Invoke();
+    }
+
+    public void OpponentTurnStart()
+    {
+        OnOpponentTurnStart?.Invoke();
+    }
+
     public void Draw()
     {
-        Debug.Log("Draw");
+        if (playerColor == GameBoard.PlayerColor.White)
+        {
+            GameBoard.instance.gameData.playerWhite.DrawCard();
+        }
+        else
+        {
+            GameBoard.instance.gameData.playerBlack.DrawCard();
+        }
         OnMyDraw?.Invoke();
     }
+
+    public void OpponentDraw()
+    {
+        OnOpponentDraw?.Invoke();
+    }
+
     public void TurnEnd()
     {
         OnMyTurnEnd?.Invoke();
@@ -236,5 +265,10 @@ public class PlayerController : MonoBehaviour
                 GameBoard.instance.gameData.playerWhite.soulOrbs++;
             GameBoard.instance.gameData.playerWhite.soulEssence = GameBoard.instance.gameData.playerWhite.soulOrbs;
         }
+    }
+
+    public void OpponentTurnEnd()
+    {
+        OnOpponentTurnEnd?.Invoke();
     }
 }

--- a/Assets/Script/Game/이벤트 목록.txt
+++ b/Assets/Script/Game/이벤트 목록.txt
@@ -1,6 +1,8 @@
 사용 가능한 이벤트 목록
 
 PlayerController
+    public Action OnMyTurnStart;
+    public Action OnOpponentTurnStart;
     public Action OnMyDraw;
     public Action OnOpponentDraw;
     public Action OnMyTurnEnd;
@@ -17,3 +19,6 @@ ChessPiece
     public Action<ChessPiece, int> OnAttacked;
     public Action OnSpellAttacked;
     public Action<Vector2Int> OnMove;
+
+GameBoard
+    public Action<ChessPiece> OnPieceKilled;

--- a/Assets/Script/Game/카드 발동 조건.txt
+++ b/Assets/Script/Game/카드 발동 조건.txt
@@ -1,0 +1,27 @@
+카드 발동 조건
+    (내/상대) 턴이 끝날 때
+    => PlayerController의 OnMyTurnEnd, OnOpponentTurnEnd
+
+    (내/상대)턴이 시작될 때
+    => PlayerController의 OnMyTurnStart, OnOpponentTurnStart
+
+    이 기물이 적을 공격하여 처치했을 때
+    => ChessPiece의 OnKill
+
+    (적/내) 기물이 처치되면            
+    => GameBoard의 OnPieceKilled (매개변수 ChessPiece 통해 적 기물인지, 내 기물인지 확인)
+
+    상대 턴에 / 내 턴에                       
+    => GameBoard의 CurrentPlayerController의 IsMyTurn 통해 검사
+
+    (내/상대)가 카드를 뽑을 때
+    => PlayerController의 OnMyDraw, OnOpponentDraw
+
+    (적/내) 기물에게 피해를 받은       
+    => GameData의 PieceObjects 받아와 적, 아군 구분 후 (HP < maxHP)이면 발동
+
+    내 기물에게 영혼이 부여되어 있다면 
+    => 선택된 기물 ChessPiece의 soul이 null이 아니면 발동
+
+    카드를 낼 때                       
+    => 소울 카드: OnInfuse 활용 / 마법 카드: TargetingEffect의 EffectAction 활용

--- a/Assets/Script/Game/카드 발동 조건.txt.meta
+++ b/Assets/Script/Game/카드 발동 조건.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a7ec16cd5128e7b4eabc7176281a6d16
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Test/DeckTester.cs
+++ b/Assets/Script/Test/DeckTester.cs
@@ -37,9 +37,6 @@ public class DeckTester : MonoBehaviour
             instantiatedCard.FlipBack();
             player.deck.Add(instantiatedCard);
         }
-
-        gameBoard.myController.OnOpponentTurnEnd += () => player.DrawCard();
-
         player.OnGetCard += (card) => card.transform.SetParent(handAnchor);
 
         player.Initialize();

--- a/Assets/Script/UI/LocalTestGameSceneUI.cs
+++ b/Assets/Script/UI/LocalTestGameSceneUI.cs
@@ -31,7 +31,13 @@ public class LocalController : MonoBehaviour
             blackController.enabled = true;
 
             whiteController.TurnEnd();
-            blackController.OnOpponentTurnEnd?.Invoke();
+            blackController.OpponentTurnEnd();
+
+            blackController.TurnStart();
+            whiteController.OpponentTurnStart();
+
+            blackController.Draw();
+            whiteController.OpponentDraw();
         }
         else
         {
@@ -41,7 +47,13 @@ public class LocalController : MonoBehaviour
             whiteController.enabled = true;
 
             blackController.TurnEnd();
-            whiteController.OnOpponentTurnEnd?.Invoke();
+            whiteController.OpponentTurnEnd();
+
+            whiteController.TurnStart();
+            blackController.OpponentTurnStart();
+
+            whiteController.Draw();
+            blackController.OpponentDraw();
         }
     }
 


### PR DESCRIPTION
효과 발동 조건 구현
- PlayerController에 isMyTurn 변수 추가
(게임씬의 인스펙터에서 먼저 시작하는 PlayerController에 isMyTurn은 true로 설정 필요)
- 이벤트 목록.txt 수정 및 카드 발동 조건.txt 추가

영혼 효과 제거 구현
- ChessPiece의 Kill()에 RemoveSoul() 추가
- 영혼 효과 제거 구현: 펜니르, 프리그, 수르트, 토르, 아벨, 베헤모스, 돈키호테, 크라켄, 호수의 여신, 모르건 르 페이

**소울 카드 구현 시 주의사항**
소울카드의 Awake에서 OnInfuse가 아닌 다른 곳에 이벤트 등록할 경우, OnDisable에서 Awake에 등록한 이벤트 제거해주어야 함 (Surtr 스크립트 참고)
-> ShowCard에서 소울 카드를 Instantiate하면 Awake 발동돼서 이벤트 중복 등록되기 때문