### PR TITLE
버프 및 키워드 구현

### DIFF
--- a/Assets/Script/Game/Card/Cards/Greek/Poseidon.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/Poseidon.cs
@@ -18,7 +18,7 @@ public class Poseidon : SoulCard
         {
             if (pieceList[i] != gameObject.GetComponent<SoulCard>().InfusedPiece)
             {
-                pieceList[i].HP -= 25;
+                pieceList[i].MinusHP(25);
             }
         }
     }

--- a/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
@@ -18,5 +18,8 @@ public class Fenrir : SoulCard
     {
         InfusedPiece.AD += IncreaseAmountAD;
         InfusedPiece.maxHP += IncreaseAmountHP;
+
+        chessPiece.buff.buffedAD += IncreaseAmountAD;
+        chessPiece.buff.buffedHP += IncreaseAmountHP;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Thor.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Thor.cs
@@ -18,6 +18,6 @@ public class Thor : SoulCard
         if (enemyPieceList.Count == 0)
             return;
 
-        enemyPieceList[Random.Range(0, enemyPieceList.Count)].HP -= InfusedPiece.AD;
+        enemyPieceList[Random.Range(0, enemyPieceList.Count)].MinusHP(InfusedPiece.AD);
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/Kraken.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Kraken.cs
@@ -27,7 +27,7 @@ public class Kraken : SoulCard
         for (int i = 0; i < repeat; i++)
         {
             int ran = Random.Range(0, targets.Count);
-            targets[ran].HP -= damage;
+            targets[ran].MinusHP(damage);
 
             if (!targets[ran].isAlive)
                 targets.Remove(targets[ran]);

--- a/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
+++ b/Assets/Script/Game/Card/Cards/Western/MorganLeFay.cs
@@ -24,14 +24,14 @@ public class MorganLeFay : SoulCard
             if (GameBoard.instance.gameData.pieceObjects[i].pieceColor == piece.pieceColor)
             {
                 //체력이 깎여있는 아군만 pieceList에 추가해서 그 중에서 무작위 회복
-                if (GameBoard.instance.gameData.pieceObjects[i].HP != GameBoard.instance.gameData.pieceObjects[i].maxHP)
+                if (GameBoard.instance.gameData.pieceObjects[i].GetHP != GameBoard.instance.gameData.pieceObjects[i].maxHP)
                     pieceList.Add(GameBoard.instance.gameData.pieceObjects[i]);
             }
         }
         if (pieceList.Count > 0)
         {
             int temp = Random.Range(0, pieceList.Count);
-            pieceList[temp].HP = pieceList[temp].maxHP;
+            pieceList[temp].AddHP(pieceList[temp].maxHP - pieceList[temp].GetHP);
         }
     }
 }

--- a/Assets/Script/Game/Card/TargetingEffect.cs
+++ b/Assets/Script/Game/Card/TargetingEffect.cs
@@ -71,9 +71,9 @@ public abstract class TargetingEffect : Effect
                         obj => (
                             (obj.pieceType & targetPieceType) != 0)
                             && (obj.pieceColor == playerColor ? isFriendly : isOpponent)
-                            && (obj.pieceColor == playerColor || obj.pieceType != ChessPiece.PieceType.King)
-                            && (condition == null ? true : condition(obj))
-                        ).Cast<TargetableObject>().ToList();
+                            && (obj.pieceColor == playerColor || (obj.pieceType != ChessPiece.PieceType.King && obj.GetKeyword(Keyword.Type.Stealth) != 1))
+                            && (condition == null ? true : condition(obj)
+                        )).Cast<TargetableObject>().ToList();
                 default:
                     return new List<TargetableObject>();
             }

--- a/Assets/Script/Game/ChessPieces/Bishop.cs
+++ b/Assets/Script/Game/ChessPieces/Bishop.cs
@@ -43,7 +43,8 @@ public class Bishop : ChessPiece
                     //해당 칸에 적 기물이 있을 경우 이동 가능
                     if (blockingPiece.pieceColor != this.pieceColor)
                     {
-                        movableCoordinates.Add(targetCoordinate);
+                        if (blockingPiece.GetKeyword(Keyword.Type.Stealth) != 1)
+                            movableCoordinates.Add(targetCoordinate);
                     }
                     break;
                 }

--- a/Assets/Script/Game/ChessPieces/Bishop.cs
+++ b/Assets/Script/Game/ChessPieces/Bishop.cs
@@ -8,6 +8,8 @@ public class Bishop : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
+        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;
 

--- a/Assets/Script/Game/ChessPieces/ChessPiece.cs
+++ b/Assets/Script/Game/ChessPieces/ChessPiece.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using JetBrains.Annotations;
@@ -131,6 +131,8 @@ abstract public class ChessPiece : TargetableObject
     [SerializeField]
     private int _maxHP;
 
+    protected int moveCount;
+
     private PieceObject pieceObject;
     private SpriteRenderer spriteRenderer;
 
@@ -145,6 +147,7 @@ abstract public class ChessPiece : TargetableObject
     //public Action OnGetMovableCoordinate;
     public Action<Vector2Int> OnMove;
 
+    public Buff buff;
     private Dictionary<Keyword.Type, int> keywordDictionary;    // 1 true, 0 false (방어력은 N)
 
     private int _tauntNumber;
@@ -173,6 +176,8 @@ abstract public class ChessPiece : TargetableObject
         }
 
         isSoulSet = false;
+
+        buff = new Buff();
     }
 
     /// <summary>
@@ -276,6 +281,8 @@ abstract public class ChessPiece : TargetableObject
         maxHP -= soul.HP;
         AD -= soul.AD;
 
+        RemoveBuff();
+
         spriteRenderer.sprite = defaultSprite;
 
         Destroy(soul);
@@ -307,7 +314,7 @@ abstract public class ChessPiece : TargetableObject
             if (soul != null)
             {
                 //soul.RemoveEffect();
-                //Remove Buff
+                RemoveBuff();
             }
         }
         else if (keywordType == Keyword.Type.Rush)
@@ -407,6 +414,23 @@ abstract public class ChessPiece : TargetableObject
 
             return tauntPiece;
         }
+    }
+
+    public void RemoveBuff()        // RemoveSoul과 침묵 키워드에서만 호출
+    {
+        _currentHP -= buff.buffedHP;
+        if (_currentHP <= 0) _currentHP = 1;
+        
+        attackDamage -= buff.buffedAD;
+        if (attackDamage < 0) attackDamage = 0;
+
+        moveCount -= buff.buffedMoveCount;
+        if (moveCount < 1) moveCount = 1;
+
+        buff.Clear();
+
+        pieceObject.HPText.text = _currentHP.ToString();
+        pieceObject.ADText.text = attackDamage.ToString();
     }
     
 

--- a/Assets/Script/Game/ChessPieces/King.cs
+++ b/Assets/Script/Game/ChessPieces/King.cs
@@ -50,7 +50,8 @@ public class King : ChessPiece
                     //해당 칸에 적 기물이 있을 경우 이동 가능
                     if (blockingPiece.pieceColor != this.pieceColor)
                     {
-                        movableCoordinates.Add(targetCoordinate);
+                        if (blockingPiece.GetKeyword(Keyword.Type.Stealth) != 1)
+                            movableCoordinates.Add(targetCoordinate);
                     }
                 }
             }

--- a/Assets/Script/Game/ChessPieces/King.cs
+++ b/Assets/Script/Game/ChessPieces/King.cs
@@ -11,6 +11,8 @@ public class King : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
+        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;
 

--- a/Assets/Script/Game/ChessPieces/Knight.cs
+++ b/Assets/Script/Game/ChessPieces/Knight.cs
@@ -8,6 +8,8 @@ public class Knight : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
+        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;
 

--- a/Assets/Script/Game/ChessPieces/Knight.cs
+++ b/Assets/Script/Game/ChessPieces/Knight.cs
@@ -47,7 +47,8 @@ public class Knight : ChessPiece
                     //해당 칸에 적 기물이 있을 경우 이동 가능
                     if (blockingPiece.pieceColor != this.pieceColor)
                     {
-                        movableCoordinates.Add(targetCoordinate);
+                        if (blockingPiece.GetKeyword(Keyword.Type.Stealth) != 1)
+                            movableCoordinates.Add(targetCoordinate);
                     }
                 }
             }

--- a/Assets/Script/Game/ChessPieces/Pawn.cs
+++ b/Assets/Script/Game/ChessPieces/Pawn.cs
@@ -10,6 +10,8 @@ public class Pawn : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
+        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;
 

--- a/Assets/Script/Game/ChessPieces/Pawn.cs
+++ b/Assets/Script/Game/ChessPieces/Pawn.cs
@@ -65,7 +65,8 @@ public class Pawn : ChessPiece
                 //해당 칸에 위치한 기물이 상대 기물 경우 이동 가능
                 if (blockingPiece != null)
                     if (blockingPiece.pieceColor != pieceColor)
-                        movableCoordinates.Add(targetCoordinate);
+                        if (blockingPiece.GetKeyword(Keyword.Type.Stealth) != 1)
+                            movableCoordinates.Add(targetCoordinate);
             }
         }
 

--- a/Assets/Script/Game/ChessPieces/PieceInfo.cs
+++ b/Assets/Script/Game/ChessPieces/PieceInfo.cs
@@ -26,7 +26,7 @@ public class PieceInfo : MonoBehaviour
             default : pieceTypeText = "오류"; break;
         }
 
-        temp = "종류 : " + pieceTypeText + "\nHP : " + chessPiece.HP + " / " + chessPiece.maxHP;
+        temp = "종류 : " + pieceTypeText + "\nHP : " + chessPiece.GetHP + " / " + chessPiece.maxHP;
         if (chessPiece.soul != null) temp += "(+" + chessPiece.soul.HP + ")";
         temp += "\nAD : " + chessPiece.AD;
         if (chessPiece.soul != null) temp += "(+" + chessPiece.soul.AD + ")";

--- a/Assets/Script/Game/ChessPieces/PieceInfo.cs
+++ b/Assets/Script/Game/ChessPieces/PieceInfo.cs
@@ -30,8 +30,38 @@ public class PieceInfo : MonoBehaviour
         if (chessPiece.soul != null) temp += "(+" + chessPiece.soul.HP + ")";
         temp += "\nAD : " + chessPiece.AD;
         if (chessPiece.soul != null) temp += "(+" + chessPiece.soul.AD + ")";
-        if (chessPiece.soul != null) temp += "\n \n[부여된 영혼]\n" + chessPiece.soul.cardName;
-        //TODO : 버프/디버프 기능 완성 후 BuffText/DebuffText 조합 필요
+        if (chessPiece.soul != null) temp += "\n부여된 영혼 :" + chessPiece.soul.cardName;
+
+        //Buff Text
+        temp += "\n[버프 목록]\n";
+        foreach (Buff.BuffInfo buffInfo in chessPiece.buff.buffList)
+        {
+            string buffText;
+            string currentSourceName = buffInfo.sourceName;
+            string currentValue = buffInfo.value > 0 ? "+" + buffInfo.value.ToString() : buffInfo.value.ToString();
+            string currentDescription = buffInfo.description;
+            switch (buffInfo.buffType)
+            {
+                case Buff.BuffType.HP:
+                    buffText = $"{currentSourceName} : HP {currentValue}";
+                    break;
+                case Buff.BuffType.AD:
+                    buffText = $"{currentSourceName} : AD {currentValue}";
+                    break;
+                case Buff.BuffType.MoveCount:
+                    buffText = $"'{currentSourceName} : 이동 횟수 {currentValue}";
+                    break;
+                case Buff.BuffType.Description:
+                    buffText = currentDescription;
+                    break;
+                default:
+                    buffText = "";
+                    break;
+            }
+            buffText += "\n";
+
+            temp += buffText;
+        }
 
         infoText.text = temp;
     }

--- a/Assets/Script/Game/ChessPieces/Quene.cs
+++ b/Assets/Script/Game/ChessPieces/Quene.cs
@@ -50,7 +50,8 @@ public class Quene : ChessPiece
                     //해당 칸에 적 기물이 있을 경우 이동 가능
                     if (blockingPiece.pieceColor != this.pieceColor)
                     {
-                        movableCoordinates.Add(targetCoordinate);
+                        if (blockingPiece.GetKeyword(Keyword.Type.Stealth) != 1)
+                            movableCoordinates.Add(targetCoordinate);
                     }
                     break;
                 }

--- a/Assets/Script/Game/ChessPieces/Quene.cs
+++ b/Assets/Script/Game/ChessPieces/Quene.cs
@@ -11,6 +11,8 @@ public class Quene : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
+        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;
 

--- a/Assets/Script/Game/ChessPieces/Rook.cs
+++ b/Assets/Script/Game/ChessPieces/Rook.cs
@@ -9,6 +9,8 @@ public class Rook : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
+        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;
 

--- a/Assets/Script/Game/ChessPieces/Rook.cs
+++ b/Assets/Script/Game/ChessPieces/Rook.cs
@@ -44,7 +44,8 @@ public class Rook : ChessPiece
                     //해당 칸에 적 기물이 있을 경우 이동 가능
                     if (blockingPiece.pieceColor != this.pieceColor)
                     {
-                        movableCoordinates.Add(targetCoordinate);
+                        if (blockingPiece.GetKeyword(Keyword.Type.Stealth) != 1)
+                            movableCoordinates.Add(targetCoordinate);
                     }
                     break;
                 }

--- a/Assets/Script/Game/Effects/Buff.cs
+++ b/Assets/Script/Game/Effects/Buff.cs
@@ -1,30 +1,106 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static Buff;
 
 // 기본 AD, HP, MoveCount 등은 저장 X, 버프된 값만 저장
-// 구속 당할 때 제거되지 않고 침묵 당할 때 제거되는 변수들 저장하는 클래스
 public class Buff : Effect
 {
-    public int buffedHP;                    //음수 = 디버프, 양수 = 버프
-    public int buffedAD;
-    public int buffedMoveCount;
-    public bool canPassThroughPieces;
+    public enum BuffType                    // 일단 수치로 나타낼 수 있는 체력, 공격력, 이동횟수 버프만 따로 분류했습니다.
+    {
+        HP,                                 // 음수, 양수 상관 없음 (버프, 디버프 구분X)
+        AD,
+        MoveCount,
+        Description
+    }
+
+    public struct BuffInfo
+    {
+        public string sourceName;           // 버프를 준 주체
+        public BuffType buffType;           // 버프 종류
+        public int value;                   // 버프 값 (버프 종류가 HP, AD, MoveCount일 때 사용)
+        public string description;          // 버프 설명 (버프 종류가 Description일 때 사용)
+        public bool isRemovableByEffect;    // 침묵, 영혼 교체에 의해 제거되는 버프인지 나타냄
+    }
+
+    private List<BuffInfo> _buffList;
+    public List<BuffInfo> buffList { get => _buffList; }
 
     public Buff()
     {
-        buffedHP = 0;
-        buffedAD = 0;
-        buffedMoveCount = 0;
-        canPassThroughPieces = false;
+        _buffList = new();
     }
 
-    public void Clear()
+    public void AddBuffByValue(string sourceName, BuffType buffType, int value, bool isRemovableByEffect)   // 버프 종류가 HP, AD, MoveCount일 때 사용
     {
-        buffedHP = 0;
-        buffedAD = 0;
-        buffedMoveCount = 0;
-        canPassThroughPieces = false;
+        if (buffType != BuffType.Description && FindBuff(sourceName, buffType, out int index))              // 기존에 있는 버프일 경우 수치만 조정
+        {
+            BuffInfo newBuffInfo = _buffList[index];
+            if (buffType == BuffType.HP || buffType == BuffType.AD || buffType == BuffType.MoveCount)
+                newBuffInfo.value += value;
+            _buffList[index] = newBuffInfo;
+        }
+        else                                                                                                // 기존에 없는 버프일 경우 새로 추가
+        {
+            BuffInfo buffInfo = new();
+
+            buffInfo.sourceName = sourceName;
+            buffInfo.buffType = buffType;
+            buffInfo.value = value;
+            buffInfo.description = "";
+            buffInfo.isRemovableByEffect = isRemovableByEffect;
+
+            _buffList.Add(buffInfo);
+        }
+    }
+
+    public void AddBuffByDescription(string sourceName, BuffType buffType, string description, bool isRemovableByEffect)              // 버프 종류가 Description일 때 사용
+    {
+        BuffInfo buffInfo = new();
+
+        buffInfo.sourceName = sourceName;
+        buffInfo.buffType = buffType;
+        buffInfo.value = 0;
+        buffInfo.description = description;
+        buffInfo.isRemovableByEffect = isRemovableByEffect;
+
+        _buffList.Add(buffInfo);
+    }
+
+    public bool TryRemoveSpecificBuff(string sourceName, BuffType buffType) 
+    {
+        if (FindBuff(sourceName, buffType, out int index))
+        {
+            _buffList.RemoveAt(index);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    public void ClearBuffList()
+    {
+        for (int i = _buffList.Count - 1; i >= 0; i--)
+        {
+            if (_buffList[i].isRemovableByEffect)
+                _buffList.RemoveAt(i);
+        }
+    }
+
+    private bool FindBuff(string sourceName, BuffType buffType, out int index)
+    {
+        for (int i = 0; i < _buffList.Count; i++)
+        {
+            if (_buffList[i].sourceName == sourceName && _buffList[i].buffType == buffType)
+            {
+                index = i;
+                return true;
+            }
+        }
+        index = -1;
+        return false;
     }
 
     public override void EffectAction()

--- a/Assets/Script/Game/Effects/Buff.cs
+++ b/Assets/Script/Game/Effects/Buff.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// 기본 AD, HP, MoveCount 등은 저장 X, 버프된 값만 저장
+// 구속 당할 때 제거되지 않고 침묵 당할 때 제거되는 변수들 저장하는 클래스
+public class Buff : Effect
+{
+    public int buffedHP;                    //음수 = 디버프, 양수 = 버프
+    public int buffedAD;
+    public int buffedMoveCount;
+    public bool canPassThroughPieces;
+
+    public Buff()
+    {
+        buffedHP = 0;
+        buffedAD = 0;
+        buffedMoveCount = 0;
+        canPassThroughPieces = false;
+    }
+
+    public void Clear()
+    {
+        buffedHP = 0;
+        buffedAD = 0;
+        buffedMoveCount = 0;
+        canPassThroughPieces = false;
+    }
+
+    public override void EffectAction()
+    {
+
+    }
+}

--- a/Assets/Script/Game/Effects/Buff.cs.meta
+++ b/Assets/Script/Game/Effects/Buff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f25d2d74340d61e4eb26bd06d5b4557e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/Effects/Execution.cs
+++ b/Assets/Script/Game/Effects/Execution.cs
@@ -12,13 +12,13 @@ public class Execution : TargetingEffect
     {
         foreach (var target in targets)
         {
-            if ((target as ChessPiece).HP < standardHP)
+            if ((target as ChessPiece).GetHP < standardHP)
             {
-                (target as ChessPiece).HP -= insteadAD;
+                (target as ChessPiece).MinusHP(insteadAD);
             }
             else
             {
-                (target as ChessPiece).HP -= basicAD;
+                (target as ChessPiece).MinusHP(basicAD);
             }
         }
     }

--- a/Assets/Script/Game/Effects/Keyword.cs
+++ b/Assets/Script/Game/Effects/Keyword.cs
@@ -1,10 +1,12 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class Keyword : Effect
 {
-    public enum type
+    public enum Type
     {
         Defense,        // 방어력
         Immunity,       // 면역
@@ -16,6 +18,8 @@ public class Keyword : Effect
         Silence,        // 침묵
         Rush            // 돌진
     }
+
+    public static Type[] AllKeywords { get => Enum.GetValues(typeof(Type)).Cast<Type>().ToArray(); }
 
     public override void EffectAction()
     {

--- a/Assets/Script/Game/Effects/Keyword.cs
+++ b/Assets/Script/Game/Effects/Keyword.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Keyword : Effect
+{
+    public enum type
+    {
+        Defense,        // 방어력
+        Immunity,       // 면역
+        Taunt,          // 도발
+        Shield,         // 보호막
+        Stun,           // 기절
+        Restraint,      // 구속
+        Stealth,        // 은신
+        Silence,        // 침묵
+        Rush            // 돌진
+    }
+
+    public override void EffectAction()
+    {
+
+    }
+}

--- a/Assets/Script/Game/Effects/Keyword.cs.meta
+++ b/Assets/Script/Game/Effects/Keyword.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1bea52819a5ef34b9dd9d555819d241
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/GameData.cs
+++ b/Assets/Script/Game/GameData.cs
@@ -20,6 +20,12 @@ public class GameData
     public PlayerData playerWhite;
     public PlayerData playerBlack;
 
+    public int tauntNumber          // 도발 부여 순서 전달
+    {
+        get => _tauntNumber++;
+    }
+    private int _tauntNumber = 0;
+
     public bool TryAddPiece(ChessPiece piece)
     {
         if (pieceObjects.Any(obj => obj.coordinate == piece.coordinate))


### PR DESCRIPTION
### 버프 구현
**Buff 클래스 추가**
- ChessPiece에 RemoveBuff 추가
- SCH-022(영혼 효과 제거 구현) 기능이 일부 필요해서 머지 후 일부 수정 필요

### **키워드 구현**
**keyword 클래스 추가**
- 키워드 enum Type 저장

**ChessPiece에 keywordDictionary 추가 (자료형 <Keyword.Type, int>)**
 - int 부분이 1이면 키워드가 활성화된 상태, 0이면 비활성화된 상태
 - 방어력의 경우 int 부분이 수치를 나타냄 (0이면 비활성화, 5면 방어력 5인 상태)
 - SetKeyword를 통해 키워드 부여 가능 (매개변수 n을 0으로 주면 비활성화 가능)
 - GetKeyword를 통해 키워드 확인 가능, 1이면 활성화 0이면 비활성화 
   (방어력의 경우 1이상이면 활성화 및 그 수치가 방어력 수치에 해당)

**HP 관련 함수 세분화 (MinusHP, AddHP, GetHp)**
 - MinusHP: 데미지를 받아 체력을 깎음 (방어력, 면역, 도발, 보호막의 영향 받음)
 - AddHP: 힐 (maxHP 이상 증가 불가)
 - GetHP: _currentHP 반환

**소울 부여 시 그 턴 이동 제한**
- protected bool isSoulSet 변수를 통해 한 턴 동안만 이동을 제한함 (true면 이동 불가)
- 턴 종료 이벤트에 MakeIsSoulSetFalse 함수 등록, 턴 종료 시 isSoulSet 변수 false됨

**키워드**
- 방어력: 체력 감소 시 방어력만큼 덜 감소
- 면역: 체력 감소 시 감소하지 않음
- 도발: 어떠한 기물이든지 공격 받을 때 주변에 아군 도발 기물이 있는지 확인, 가장 최근에 도발이 부여된 기물이 선택됨
- 보호막: 체력 감소 시 한 번 감소하지 않음
- 기절: 키워드가 활성화될 때, 턴 종료 이벤트에 기절 해제 함수(Unstun) 등록
- 구속: 키워드가 활성화될 때, RemoveEffect를 통해 효과 비활성화, 구속 해제 함수(Unrestraint)를 통해 효과를 다시 활성화 가능
- 은신: 키워드가 활성화되어 있으면, TargetingEffect에 지정되지 않고, 적 기물이 이동하려 할 때 지정 불가
- 침묵: 키워드가 활성화될 때, RemoveEffect를 통해 효과 비활성화, RemoveBuff를 통해 버프 제거됨
- 돌진: 키워드가 활성화될 때, MakeIsSoulSetFalse 함수를 통해 isSoulSet을 바로 false로 만들어 이동 가능하게 만듦

**이외**
모든 기물의 GetMovableCoordinates 함수 수정: 기절 상태이거나 구속 상태이거나 소울이 부여된 턴이면 이동을 제한함
RemoveEffect는 효과의 비활성화, AddEffect는 효과의 활성화, RemoveBuff는 버프된 항목 제거를 의미

키워드 활성화 예시
- 방어력 10: chessPiece.SetKeyword(Keyword.Type.Defense, 10);
- 도발: chessPiece.SetKeyword(Keyword.Type.Taunt);
- 침묵: chessPiece.SetKeyword(Keyword.Type.Silence);

키워드 비활성화 예시
- 방어력 없애기: chessPiece.SetKeyword(Keyword.Type.Defense, 0);
- 은신 없애기: chessPiece.SetKeyword(Keyword.Type.Stealth, 0);

* '체력을 10으로 만듭니다'와 같은 능력이 필요할 경우 HP를 set하는 함수 필요
* 구속과 침묵의 경우, SCH-022 머지 이후 수정 및 테스트 필요