### PR TITLE
키워드 침묵, 구속 구현

### DIFF
--- a/Assets/Scenes/TestScenes/GameScene_WKH.unity
+++ b/Assets/Scenes/TestScenes/GameScene_WKH.unity
@@ -2075,11 +2075,9 @@ MonoBehaviour:
   - {fileID: -2815551797691118998, guid: 2d9947a9ca0af554ebef3f3b895f3d78, type: 3}
   deck:
   - {fileID: 4824830457768495894, guid: dc0e4c5991c664d4aaaad1229ca79999, type: 3}
-  - {fileID: 6842244014742130878, guid: ce404b57a1b095e4bbcfbec40f372c12, type: 3}
+  - {fileID: 4824830457768495894, guid: dc0e4c5991c664d4aaaad1229ca79999, type: 3}
   - {fileID: 6592858290932310892, guid: ad9ea7076351dda45bceebe2ed5d9deb, type: 3}
-  - {fileID: 599667399022218461, guid: ff82128eca4e7994fb3e11360893a803, type: 3}
-  - {fileID: -1208510047847783411, guid: 97d03e24daf82ae4486ae6ceec8dfdeb, type: 3}
-  - {fileID: 7433252666421529211, guid: fc310b2ab5a30de4298b4aea18a015f4, type: 3}
+  - {fileID: 6842244014742130878, guid: ce404b57a1b095e4bbcfbec40f372c12, type: 3}
 --- !u!4 &1323045556
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Fenrir.cs
@@ -10,15 +10,9 @@ public class Fenrir : SoulCard
     private int IncreaseAmountAD = 20;
     private int IncreaseAmountHP = 20;
 
-    private int buffedAD;
-    private int buffedHP;
-
     protected override void Awake()
     {
         base.Awake();
-
-        buffedAD = 0;
-        buffedHP = 0;
 
         OnInfuse += (ChessPiece chessPiece) => chessPiece.OnKill += IncreaseStat;
         OnInfuse += (ChessPiece chessPiece) => chessPiece.OnSoulRemoved += RemoveEffect;
@@ -29,27 +23,17 @@ public class Fenrir : SoulCard
         InfusedPiece.AD += IncreaseAmountAD;
         InfusedPiece.maxHP += IncreaseAmountHP;
 
-
-        //chessPiece.buff.AddBuffByValue(this.cardName, Buff.BuffType.AD, IncreaseAmountAD, true);
-        //chessPiece.buff.AddBuffByValue(this.cardName, Buff.BuffType.HP, IncreaseAmountHP, true);
-
-        buffedAD += IncreaseAmountAD;
-        buffedHP += IncreaseAmountHP;
+        InfusedPiece.buff.AddBuffByValue(this.cardName, Buff.BuffType.AD, IncreaseAmountAD, true);
+        InfusedPiece.buff.AddBuffByValue(this.cardName, Buff.BuffType.HP, IncreaseAmountHP, true);
     }
 
     public override void AddEffect()
     {
-        InfusedPiece.maxHP += buffedHP;
-        InfusedPiece.AD += buffedAD;
-
         InfusedPiece.OnKill += IncreaseStat;
     }
 
     public override void RemoveEffect()
     {
-        InfusedPiece.maxHP -= buffedHP;
-        InfusedPiece.AD -= buffedAD;
-
         InfusedPiece.OnKill -= IncreaseStat;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Behemoth.cs
@@ -5,8 +5,6 @@ using UnityEngine;
 public class Behemoth : SoulCard
 {
     protected override int CardID => Card.cardIdDict["베헤모스"];
-    private int buffedHP;
-    private int buffedAD;
 
     protected override void Awake()
     {
@@ -16,9 +14,6 @@ public class Behemoth : SoulCard
 
     public void SoulEffect(ChessPiece chessPiece)
     {
-        buffedHP = 0;
-        buffedAD = 0;
-
         GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
 
         chessPiece.OnSoulRemoved += RemoveEffect;
@@ -29,23 +24,17 @@ public class Behemoth : SoulCard
         InfusedPiece.maxHP += 10;
         InfusedPiece.AD += 10;
 
-        buffedHP += 10;
-        buffedAD += 10;
+        InfusedPiece.buff.AddBuffByValue(cardName, Buff.BuffType.HP, 10, true);
+        InfusedPiece.buff.AddBuffByValue(cardName, Buff.BuffType.AD, 10, true);
     }
 
     public override void AddEffect()
     {
-        InfusedPiece.maxHP += buffedHP;
-        InfusedPiece.AD += buffedAD;
-
         GameBoard.instance.myController.OnMyTurnEnd += SoulEffect2;
     }
 
     public override void RemoveEffect()
     {
-        InfusedPiece.maxHP -= buffedHP;
-        InfusedPiece.AD -= buffedAD;
-
         GameBoard.instance.myController.OnMyTurnEnd -= SoulEffect2;
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
+++ b/Assets/Script/Game/Card/Cards/Western/LadyOfTheLake.cs
@@ -32,6 +32,9 @@ public class LadyOfTheLake : SoulCard
         int temp = Random.Range(0, pieceList.Count);
         pieceList[temp].maxHP += 20;
         pieceList[temp].AD += 20;
+
+        pieceList[temp].buff.AddBuffByValue(cardName, Buff.BuffType.HP, 20, true);
+        pieceList[temp].buff.AddBuffByValue(cardName, Buff.BuffType.AD, 20, true);
     }
 
     public override void AddEffect()

--- a/Assets/Script/Test/DeckTester.cs
+++ b/Assets/Script/Test/DeckTester.cs
@@ -43,25 +43,4 @@ public class DeckTester : MonoBehaviour
 
         //player.Mulligan();
     }
-
-    private void Update()
-    {
-        if (Input.GetKeyDown(KeyCode.Q))
-        {
-            player.RemoveHandCards();
-        }
-        if (Input.GetKeyDown(KeyCode.W))
-        {
-            Debug.Log("Try to Remove First Card in Hand");
-            bool result = player.TryRemoveCardInHand(player.hand[0]);
-        }
-        if (Input.GetKeyDown(KeyCode.E))
-        {
-            bool result = player.TryAddCardInHand(Instantiate(deck[0]));
-        }
-        if (Input.GetKeyDown(KeyCode.R))
-        {
-            player.RemoveDeckCards();
-        }
-    }
 }


### PR DESCRIPTION
영혼 부여 시 침묵 초기화
구속된 기물의 영혼 교체할 때 구속 유지
구속 -> 침묵 -> 구속 해제 순으로 적용될 때 효과 활성화되지 않도록 수정
버프 부여 일부 구현: 펜리르, 베헤모스, 호수의 여인
덱 테스터 디버깅 코드 삭제

SCH-023이 머지돼서 SCH-029에 구현했습니다.