### PR TITLE
무덤 관련 구현 수정

### DIFF
--- a/Assets/Script/Game/ChessPieces/ChessPiece.cs
+++ b/Assets/Script/Game/ChessPieces/ChessPiece.cs
@@ -157,7 +157,7 @@ abstract public class ChessPiece : TargetableObject
     private SpriteRenderer accessory = null;
     [SerializeField]
     SpriteRenderer accessoryPrefab;
-    private PieceEffectIcon effectIcon = null;
+    public PieceEffectIcon effectIcon = null;
     [SerializeField]
     PieceEffectIcon effectIconPrefab;
     private PieceEffectIcon moveRestrictionIcon = null;
@@ -421,8 +421,17 @@ abstract public class ChessPiece : TargetableObject
     private void MakeIsSoulSetFalse()
     {
         isSoulSet = false;
-        if (moveRestrictionIcon != null) { moveRestrictionIcon.DestroyIcon(); moveRestrictionIcon = null; }
+        DestroyMoveRestrictionIcon();
         GameBoard.instance.myController.OnMyTurnEnd -= MakeIsSoulSetFalse;
+    }
+
+    public void DestroyMoveRestrictionIcon()
+    {
+        if (moveRestrictionIcon != null) 
+        { 
+            moveRestrictionIcon.DestroyIcon();
+            moveRestrictionIcon = null;
+        }
     }
 
     // 스턴 해제 (다시 턴 시작 시 호출)

--- a/Assets/Script/Game/ChessPieces/PieceEffectIcon.cs
+++ b/Assets/Script/Game/ChessPieces/PieceEffectIcon.cs
@@ -46,4 +46,9 @@ public class PieceEffectIcon : MonoBehaviour
         CancelInvoke("DestroyIcon");
         Destroy(gameObject);
     }
+
+    public void RemoveIcon()
+    {
+        spriteRenderer.sprite = null;
+    }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Western/GreenKnightEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Western/GreenKnightEffect.cs
@@ -25,12 +25,12 @@ public class GreenKnightEffect : TargetingEffect
 
     public override void EffectAction(PlayerController player)
     {
+        gameObject.GetComponent<SoulCard>().InfusedPiece.SetKeyword(Keyword.Type.Taunt);
+        gameObject.GetComponent<SoulCard>().InfusedPiece.buff.AddBuffByKeyword(gameObject.GetComponent<SoulCard>().cardName, Buff.BuffType.Taunt);
+
         foreach (var target in targets)
         {
             (target as ChessPiece).Attack(gameObject.GetComponent<SoulCard>().InfusedPiece);
         }
-
-        gameObject.GetComponent<SoulCard>().InfusedPiece.SetKeyword(Keyword.Type.Taunt);
-        gameObject.GetComponent<SoulCard>().InfusedPiece.buff.AddBuffByKeyword(gameObject.GetComponent<SoulCard>().cardName, Buff.BuffType.Taunt);
     }
 }

--- a/Assets/Script/Game/GameBoard.cs
+++ b/Assets/Script/Game/GameBoard.cs
@@ -111,7 +111,8 @@ public class GameBoard : MonoBehaviour
             targetPiece.coordinate = Vector2Int.right * (gameData.blackGraveyard.Count - 1) + Vector2Int.up * GameData.BOARD_SIZE;
         }
 
-        //targetPiece.DestroyMoveRestrictionIcon();
+        targetPiece.effectIcon.RemoveIcon();
+        targetPiece.DestroyMoveRestrictionIcon();
         gameData.pieceObjects.Remove(targetPiece);
 
         chessBoard.SetPiecePositionByCoordinate(targetPiece);

--- a/Assets/Script/Game/GameBoard.cs
+++ b/Assets/Script/Game/GameBoard.cs
@@ -100,10 +100,20 @@ public class GameBoard : MonoBehaviour
     {
         OnPieceKilled?.Invoke(targetPiece);
 
-        gameData.graveyard.Add(targetPiece);
+        if (targetPiece.pieceColor == PlayerColor.White)
+        {
+            gameData.whiteGraveyard.Add(targetPiece);
+            targetPiece.coordinate = Vector2Int.right * (gameData.whiteGraveyard.Count - 1) + Vector2Int.down;
+        }
+        else
+        {
+            gameData.blackGraveyard.Add(targetPiece);
+            targetPiece.coordinate = Vector2Int.right * (gameData.blackGraveyard.Count - 1) + Vector2Int.up * GameData.BOARD_SIZE;
+        }
+
+        //targetPiece.DestroyMoveRestrictionIcon();
         gameData.pieceObjects.Remove(targetPiece);
 
-        targetPiece.coordinate = Vector2Int.right * (gameData.graveyard.Count - 1) + Vector2Int.down;
         chessBoard.SetPiecePositionByCoordinate(targetPiece);
     }
 

--- a/Assets/Script/Game/GameData.cs
+++ b/Assets/Script/Game/GameData.cs
@@ -15,7 +15,8 @@ public class GameData
     public BoardSquare[,] boardSquares = new BoardSquare[BOARD_SIZE, BOARD_SIZE];
     [SerializeField]
     public List<ChessPiece> pieceObjects = new List<ChessPiece>();
-    public List<ChessPiece> graveyard = new List<ChessPiece>();
+    public List<ChessPiece> whiteGraveyard = new List<ChessPiece>();
+    public List<ChessPiece> blackGraveyard = new List<ChessPiece>();
 
     public PlayerData myPlayerData { get => GameBoard.instance.playerColor == GameBoard.PlayerColor.White ? playerWhite : playerBlack; }
     public PlayerData opponentPlayerData { get => GameBoard.instance.playerColor == GameBoard.PlayerColor.White ? playerBlack : playerWhite; }


### PR DESCRIPTION
기물 색상 별 무덤 구현
- graveyard 대신 whiteGraveyard와 blackGraveyard 추가
- KillPiece에서 색상에 맞게 무덤으로 보내고 위치 조정

기물 제거 시 시각 효과 제거
- ChessPiece와 PieceEffection에 각각 시각 효과 제거 함수 추가
- KillPiece 함수에서 시각 효과 제거 호출
- (GreenKnight의 경우 키워드 부여가 능력 발동보다 늦게 일어나 기물이 죽은 뒤 키워드가 부여돼서 시각 효과 제거 안 됐었음 -> 키워드 부여를 능력 발동보다 이전에 하도록 수정)