### PR TITLE
플레이어가 사용한 카드에 대해 카드 사용(핸드에서 제거) 전 카드 효과가 실행되던 문제 수정

### DIFF
--- a/Assets/Script/Game/PlayerController.cs
+++ b/Assets/Script/Game/PlayerController.cs
@@ -364,12 +364,11 @@ public class PlayerController : MonoBehaviour
                 photonView.RPC("UseCardRemote", RpcTarget.Others, usingCard.handIndex, new Vector3(-1, -1, -1), null);
         }
 
-        usingCard.EffectOnCardUsed?.EffectAction(this);
-
-
         GameBoard.instance.CurrentPlayerData().soulEssence -= usingCard.cost;
 
         GameBoard.instance.gameData.myPlayerData.TryRemoveCardInHand(usingCard);
+
+        usingCard.EffectOnCardUsed?.EffectAction(this);
 
         if (!(usingCard is SoulCard))
             usingCard.Destroy();


### PR DESCRIPTION
제우스, 약탈선 버그 등 카드 인덱스를 꼬아 동기화 버그를 발생시키는 주범이었던 버그를 수정

ex) 핸드가 6장 있는 상태에서 약탈선 카드 사용 시 카드를 사용한 플레이어의 게임에서는 핸드가 6장이므로 카드가 약탈꾼이 2장만 들어오고 약탈선이 핸드에서 없어지며 핸드가 총 7장이 됐지만 상대 플레이어의 게임에서는 약탈선 카드가 핸드에서 먼저 없어지고 그 후 약탈꾼 카드 3장이 정상적으로 핸드에 들어와 핸드가 8장이 됨. 제우스, 철학자 버그도 같은 메커니즘으로 발생

기존 코드에서 상대방의 카드 사용을 원격으로 적용할 때와 본인의 카드를 직접 사용할 때, ‘카드를 핸드에서 제거’와’ 카드 효과 사용’의 실행 순서가 일치하지 않았었음. 이를 카드를 핸드에서 제거한 후 카드 효과가 사용되도록 통일함