### PR TITLE
케르베로스 침묵 시 두 번 움직일 수 있는 버그 수정

### DIFF
--- a/Assets/Script/Game/ChessPieces/ChessPiece.cs
+++ b/Assets/Script/Game/ChessPieces/ChessPiece.cs
@@ -542,7 +542,7 @@ abstract public class ChessPiece : TargetableObject
             else if (buffType == Buff.BuffType.MoveCount)
             {
                 moveCount -= buffInfo.value;
-                if (moveCount < 1) moveCount = 1;
+                if (moveCount < 1) moveCount = 0;
             }
             else if (buffType == Buff.BuffType.Defense)
             {


### PR DESCRIPTION
케르베로스 침묵 시 한 번만 움직일 수 있어야 하는데 두 번까지 움직일 수 있는 버그
- SetKeyword()로 침묵될 때 soul.RemoveEffect()도 호출되고 RemoveBuff()도 호출됨 
- (직접적인 원인은 아니나 잠재적인 문제 가능성 있음)
- ChessPiece의 RemoveBuff()에서 moveCount가 1보다 작을 경우 1로 초기화되던 것이 문제
- 0으로 초기화되어야 함