### PR TITLE
카드 리워크 적용 / 키워드 제거

### DIFF
--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Apollon.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Apollon.prefab
@@ -100,8 +100,8 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 0
   rarity: 2
-  description: "[\uBCF4\uD638\uB9C9]\n[\uAC15\uB9BC] \uC774 \uD589\uC758 \uBAA8\uB4E0
-    \uB0B4 \uAE30\uBB3C\uC774 \uBCF4\uD638\uB9C9\uC744 \uC5BB\uC2B5\uB2C8\uB2E4."
+  description: "[\uBCF4\uD638\uB9C9]\n[\uAC15\uB9BC] \uC591 \uC606 \uB0B4 \uAE30\uBB3C\uC5D0\uAC8C
+    \uBCF4\uD638\uB9C9\uC744 \uBD80\uC5EC\uD569\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: 2704465689171556815}
   isInSelection: 0
   pieceRestriction: 5

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_HeavyArmoredInfantry.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_HeavyArmoredInfantry.prefab
@@ -86,14 +86,25 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 0
-    soulOrbs: 0
-    soulEssence: 0
+    playerColor: 1
+    soulOrbs: 7
+    soulEssence: 7
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck: []
-    hand: []
+    deck:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    hand:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
@@ -104,7 +115,8 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 0
   rarity: 0
-  description: "[\uBC29\uC5B4\uB3C4 5]"
+  description: "[\uAC15\uB9BC] \uC591 \uC606 \uB0B4 \uAE30\uBB3C\uC5D0\uAC8C \uCCB4\uB825\uC744
+    5 \uBD80\uC5EC\uD569\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: -2114984967717608709}
   isInSelection: 0
   pieceRestriction: 1
@@ -118,6 +130,7 @@ MonoBehaviour:
     pieceColor: 1
     sprite: {fileID: 21300000, guid: 81972bca31ce67e46954e15f7be014d7, type: 3}
   InfusedPiece: {fileID: 0}
+  increasedHP: 5
 --- !u!114 &-2114984967717608709
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_HeavyArmoredInfantry.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_HeavyArmoredInfantry.prefab
@@ -86,25 +86,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 7
-    soulEssence: 7
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hephaestus.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hephaestus.prefab
@@ -100,7 +100,7 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 0
   rarity: 2
-  description: "\uB0B4 \uD134\uC774 \uB05D\uB0A0 \uB54C, \uC601\uD63C\uC774 \uBD80\uC5EC\uB41C
+  description: "\uB0B4 \uD134\uC774 \uB05D\uB0A0 \uB54C, \uC601\uD63C\uC774 \uAE43\uB4E0
     \uBAA8\uB4E0 \uAE30\uBB3C\uC5D0\uAC8C 10 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: -4965968554084867166}
   isInSelection: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hephaestus.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hephaestus.prefab
@@ -87,6 +87,7 @@ MonoBehaviour:
     soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
+    isRevealed: 0
     deck: []
     hand: []
     deckPosition: {x: 0, y: 0}
@@ -99,9 +100,8 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 0
   rarity: 2
-  description: "\uC774 \uAE30\uBB3C\uC774 \uC774\uB3D9\uD55C \uD6C4, \uC8FC\uC704\uC758
-    \uBAA8\uB4E0 \uC601\uD63C\uC774 \uAE43\uB4E0 \uAE30\uBB3C\uC5D0\uAC8C 20\uC758
-    \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
+  description: "\uB0B4 \uD134\uC774 \uB05D\uB0A0 \uB54C, \uC601\uD63C\uC774 \uBD80\uC5EC\uB41C
+    \uBAA8\uB4E0 \uAE30\uBB3C\uC5D0\uAC8C 10 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: -4965968554084867166}
   isInSelection: 0
   pieceRestriction: 4

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hercules.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hercules.prefab
@@ -122,8 +122,7 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 0
   rarity: 1
-  description: "[\uB3C4\uBC1C] \uB0B4 \uD134\uC5D0 \uACF5\uACA9\uB825\uC774 2\uBC30\uAC00
-    \uB429\uB2C8\uB2E4."
+  description: "\uB0B4 \uD134\uC5D0 \uACF5\uACA9\uB825\uC774 2\uBC30\uAC00 \uB429\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: 1265310719377410018}
   isInSelection: 0
   pieceRestriction: 2
@@ -138,6 +137,7 @@ MonoBehaviour:
     sprite: {fileID: 21300000, guid: e3814a68c51fea14981adb355fbeb096, type: 3}
   InfusedPiece: {fileID: 0}
   playercontroller: {fileID: 0}
+  multipleAD: 2
 --- !u!114 &1265310719377410018
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hercules.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Hercules.prefab
@@ -87,31 +87,13 @@ MonoBehaviour:
   coordinate: {x: 0, y: 0}
   owner:
     playerColor: 0
-    soulOrbs: 10
-    soulEssence: 3
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_NewScytheTank.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_NewScytheTank.prefab
@@ -86,15 +86,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 0
-    soulOrbs: 1
-    soulEssence: 1
+    playerColor: 1
+    soulOrbs: 5
+    soulEssence: 5
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
     deck:
-    - {fileID: 0}
-    - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
@@ -124,7 +122,9 @@ MonoBehaviour:
     - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
-    deckPosition: {x: 7.6, y: -2.3}
+    - {fileID: 0}
+    - {fileID: 0}
+    deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
@@ -134,24 +134,18 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 0
   rarity: 0
-  description: "[\uBC29\uC5B4\uB3C4 10]\n[\uB3CC\uC9C4]"
+  description: "[\uBCF4\uD638\uB9C9]"
   EffectOnCardUsed: {fileID: 298669615360064573}
   isInSelection: 0
-  pieceRestriction: 10
+  pieceRestriction: 8
   _AD: 40
-  _HP: 10
+  _HP: 40
   accessorySpriteList:
-  - pieceType: 2
+  - pieceType: 8
     pieceColor: 0
-    sprite: {fileID: 21300000, guid: d15aba0c602e33349ad37b1a97cf982f, type: 3}
-  - pieceType: 2
-    pieceColor: 1
     sprite: {fileID: 21300000, guid: d15aba0c602e33349ad37b1a97cf982f, type: 3}
   - pieceType: 8
     pieceColor: 1
-    sprite: {fileID: 21300000, guid: d15aba0c602e33349ad37b1a97cf982f, type: 3}
-  - pieceType: 8
-    pieceColor: 0
     sprite: {fileID: 21300000, guid: d15aba0c602e33349ad37b1a97cf982f, type: 3}
   InfusedPiece: {fileID: 0}
 --- !u!114 &298669615360064573

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_NewScytheTank.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_NewScytheTank.prefab
@@ -86,44 +86,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 5
-    soulEssence: 5
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_OnlyThinkPhilosopher.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_OnlyThinkPhilosopher.prefab
@@ -86,43 +86,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 2
-    soulEssence: 1
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Typhon.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Typhon.prefab
@@ -86,41 +86,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 3
-    soulEssence: 3
+    playerColor: 0
+    soulOrbs: 10
+    soulEssence: 10
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
     deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
@@ -133,7 +105,8 @@ MonoBehaviour:
     - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
-    deckPosition: {x: 7.6, y: -2.3}
+    - {fileID: 0}
+    deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
@@ -144,7 +117,8 @@ MonoBehaviour:
   reigon: 0
   rarity: 1
   description: "[\uAC15\uB9BC] \uB0B4 \uD328\uC640 \uB371\uC5D0 \uC788\uB294 \uBAA8\uB4E0
-    \uCE74\uB4DC\uB97C \uD30C\uAD34\uD569\uB2C8\uB2E4."
+    \uCE74\uB4DC\uB97C \uD30C\uAD34\uD569\uB2C8\uB2E4.\n3\uD134 \uB4A4, \uC774 \uAE30\uBB3C\uC740
+    \uD30C\uAD34\uB429\uB2C8\uB2E4.\n"
   EffectOnCardUsed: {fileID: -504592958107433718}
   isInSelection: 0
   pieceRestriction: -1
@@ -188,6 +162,7 @@ MonoBehaviour:
     pieceColor: 0
     sprite: {fileID: 21300000, guid: 6bad8d4e9771ba14bae3ba6c48aad874, type: 3}
   InfusedPiece: {fileID: 0}
+  countdown: 3
 --- !u!114 &-504592958107433718
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Typhon.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Typhon.prefab
@@ -87,25 +87,13 @@ MonoBehaviour:
   coordinate: {x: 0, y: 0}
   owner:
     playerColor: 0
-    soulOrbs: 10
-    soulEssence: 10
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
@@ -116,9 +104,8 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 0
   rarity: 1
-  description: "[\uAC15\uB9BC] \uB0B4 \uD328\uC640 \uB371\uC5D0 \uC788\uB294 \uBAA8\uB4E0
-    \uCE74\uB4DC\uB97C \uD30C\uAD34\uD569\uB2C8\uB2E4.\n3\uD134 \uB4A4, \uC774 \uAE30\uBB3C\uC740
-    \uD30C\uAD34\uB429\uB2C8\uB2E4.\n"
+  description: "[\uAC15\uB9BC] \uB0B4 \uD328\uC640 \uB371\uC758 \uBAA8\uB4E0 \uCE74\uB4DC\uB97C
+    \uD30C\uAD34\uD569\uB2C8\uB2E4.\n3\uD134 \uB4A4, \uC774 \uAE30\uBB3C\uC740 \uD30C\uAD34\uB429\uB2C8\uB2E4.\n"
   EffectOnCardUsed: {fileID: -504592958107433718}
   isInSelection: 0
   pieceRestriction: -1

--- a/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Zeus.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Greek/Soul_Zeus.prefab
@@ -80,20 +80,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcbcffaf888250547967310df7c4bcf4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 7
-    soulEssence: 4
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
+    isRevealed: 0
     deck: []
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    deckPosition: {x: 7.6, y: -2.3}
+    hand: []
+    deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
@@ -118,6 +115,7 @@ MonoBehaviour:
     pieceColor: 1
     sprite: {fileID: 21300000, guid: 921f6d231210b274fac894b063e62d9f, type: 3}
   InfusedPiece: {fileID: 0}
+  cardAmount: 3
 --- !u!114 &-2277148209843755556
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Fenrir.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Fenrir.prefab
@@ -124,6 +124,8 @@ MonoBehaviour:
     pieceColor: 1
     sprite: {fileID: 21300000, guid: 0be8445f34efc3349b406045a2dc8f2a, type: 3}
   InfusedPiece: {fileID: 0}
+  increasedAD: 20
+  increasedHP: 20
 --- !u!114 &-3866558103305100114
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Mimir.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Mimir.prefab
@@ -104,7 +104,8 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 1
   rarity: 1
-  description: "\uB0B4 \uCE74\uB4DC\uC758 \uBE44\uC6A9\uC774 1 \uAC10\uC18C\uD569\uB2C8\uB2E4."
+  description: "\uC774 \uC601\uD63C\uC774 \uBD80\uC5EC\uB41C \uAE30\uBB3C\uC774 \uC0B4\uC544\uC788\uB294
+    \uB3D9\uC548 \uB0B4 \uCE74\uB4DC\uC758 \uBE44\uC6A9\uC774 1 \uAC10\uC18C\uD569\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: -6232363627302796207}
   isInSelection: 0
   pieceRestriction: 6
@@ -124,6 +125,7 @@ MonoBehaviour:
     pieceColor: 1
     sprite: {fileID: 21300000, guid: 1cb6ccdad8f77ba47aa475015f69d90d, type: 3}
   InfusedPiece: {fileID: 0}
+  reductionCost: 1
 --- !u!114 &-6232363627302796207
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Thor.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Thor.prefab
@@ -92,6 +92,7 @@ MonoBehaviour:
     soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
+    isRevealed: 0
     deck: []
     hand: []
     deckPosition: {x: 0, y: 0}

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Tyr.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Tyr.prefab
@@ -80,12 +80,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 722b508c31c62f24e968441158e52707, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  coordinate: {x: 0, y: 0}
   owner:
     playerColor: 1
     soulOrbs: 3
     soulEssence: 3
     maxHandCardCount: 8
     mulliganHandCount: 4
+    isRevealed: 0
     deck:
     - {fileID: 0}
     - {fileID: 0}
@@ -137,9 +139,8 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 1
   rarity: 2
-  description: "[\uB3C4\uBC1C] [\uBC29\uC5B4\uB825 10]\n[\uAC15\uB9BC] \uC801 \uAE30\uBB3C
-    \uD558\uB098\uB97C \uC120\uD0DD\uD558\uC5EC \uAD6C\uC18D\uC2DC\uD0B5\uB2C8\uB2E4.\n[\uC720\uC5B8]
-    \uADF8 \uAE30\uBB3C\uC758 \uAD6C\uC18D\uC744 \uD574\uC81C\uD569\uB2C8\uB2E4."
+  description: "\uB0B4 \uD134\uC774 \uB05D\uB0A0 \uB54C, \uBB34\uC791\uC704 \uC801
+    \uAE30\uBB3C \uD558\uB098\uB97C \uAE30\uC808\uC2DC\uD0B5\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: 2246044354094067083}
   isInSelection: 0
   pieceRestriction: 8
@@ -150,12 +151,6 @@ MonoBehaviour:
     pieceColor: 0
     sprite: {fileID: 21300000, guid: 1e68a44573e3f2b43b031db0d809391c, type: 3}
   - pieceType: 8
-    pieceColor: 1
-    sprite: {fileID: 21300000, guid: 1e68a44573e3f2b43b031db0d809391c, type: 3}
-  - pieceType: 2
-    pieceColor: 0
-    sprite: {fileID: 21300000, guid: 1e68a44573e3f2b43b031db0d809391c, type: 3}
-  - pieceType: 2
     pieceColor: 1
     sprite: {fileID: 21300000, guid: 1e68a44573e3f2b43b031db0d809391c, type: 3}
   InfusedPiece: {fileID: 0}
@@ -176,5 +171,7 @@ MonoBehaviour:
     targetPieceType: -1
     isOpponent: 1
     isFriendly: 0
+    targetTiles: 0
+    tileCoordinate: {x: 0, y: 0}
   isPositiveEffect: 0
   isNegativeEffect: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Tyr.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_Tyr.prefab
@@ -82,54 +82,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 3
-    soulEssence: 3
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    deckPosition: {x: 7.6, y: -2.3}
+    deck: []
+    hand: []
+    deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
@@ -166,12 +127,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 741eeb4953dc31a49afd4062b1754750, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  targetTypes:
-  - targetType: 0
-    targetPieceType: -1
-    isOpponent: 1
-    isFriendly: 0
-    targetTiles: 0
-    tileCoordinate: {x: 0, y: 0}
-  isPositiveEffect: 0
-  isNegativeEffect: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_UtgardaLoki.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_UtgardaLoki.prefab
@@ -92,42 +92,13 @@ MonoBehaviour:
   coordinate: {x: 0, y: 0}
   owner:
     playerColor: 0
-    soulOrbs: 9
-    soulEssence: 9
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_UtgardaLoki.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_UtgardaLoki.prefab
@@ -91,13 +91,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 10
-    soulEssence: 5
+    playerColor: 0
+    soulOrbs: 9
+    soulEssence: 9
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
     deck:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
@@ -117,12 +127,13 @@ MonoBehaviour:
     - {fileID: 0}
     - {fileID: 0}
     - {fileID: 0}
-    deckPosition: {x: 7.6, y: -2.3}
+    - {fileID: 0}
+    deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
   cardName: "\uC6B0\uD2B8\uAC00\uB974\uB2E4 \uB85C\uD0A4"
-  _cost: 2
+  _cost: 3
   illustration: {fileID: 21300000, guid: 44ee189dbcfdcf7479c0b2d1c764dc35, type: 3}
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 1
@@ -130,9 +141,9 @@ MonoBehaviour:
   description: "[\uAC15\uB9BC] \uC801 \uAE30\uBB3C \uD558\uB098\uB97C \uCE68\uBB35\uC2DC\uD0B5\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: -852172297929449117}
   isInSelection: 0
-  pieceRestriction: 36
-  _AD: 20
-  _HP: 10
+  pieceRestriction: 32
+  _AD: 30
+  _HP: 20
   accessorySpriteList:
   - pieceType: 32
     pieceColor: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_VikingWarrior.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Norse/Soul_VikingWarrior.prefab
@@ -119,6 +119,7 @@ MonoBehaviour:
     pieceColor: 1
     sprite: {fileID: 21300000, guid: 1c48a98cb2083e24db1cc04e2347ccd7, type: 3}
   InfusedPiece: {fileID: 0}
+  increasedAD: 20
 --- !u!114 &3459992950709373579
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Abel.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Abel.prefab
@@ -92,6 +92,7 @@ MonoBehaviour:
     soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
+    isRevealed: 0
     deck: []
     hand: []
     deckPosition: {x: 0, y: 0}

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Behemoth.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Behemoth.prefab
@@ -120,6 +120,8 @@ MonoBehaviour:
     sprite: {fileID: 21300000, guid: 681a72d67b7191c418bf6f39791de8bd, type: 3}
   InfusedPiece: {fileID: 0}
   player: {fileID: 0}
+  increasedAD: 10
+  increasedHP: 10
 --- !u!114 &-5580636979039151795
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Cain.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Cain.prefab
@@ -80,7 +80,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b9c6ab1dfb891f04f9d538760d6d15dd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isMine: 0
+  coordinate: {x: 0, y: 0}
+  owner:
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
+    maxHandCardCount: 8
+    mulliganHandCount: 4
+    isRevealed: 0
+    deck: []
+    hand: []
+    deckPosition: {x: 0, y: 0}
+    spellDamageIncrease: 0
+    spellDamageCoefficient: 1
   handIndex: -1
   cardName: "\uCE74\uC778"
   _cost: 4
@@ -125,3 +137,4 @@ MonoBehaviour:
   targetTypes: []
   isPositiveEffect: 0
   isNegativeEffect: 1
+  multipleAmount: 7

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_David.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_David.prefab
@@ -141,3 +141,4 @@ MonoBehaviour:
   targetTypes: []
   isPositiveEffect: 0
   isNegativeEffect: 1
+  standardAD: 70

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_DavyJones.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_DavyJones.prefab
@@ -80,7 +80,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c69c5999680c2084f8b539f4a2b7435a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isMine: 0
+  coordinate: {x: 0, y: 0}
+  owner:
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
+    maxHandCardCount: 8
+    mulliganHandCount: 4
+    isRevealed: 0
+    deck: []
+    hand: []
+    deckPosition: {x: 0, y: 0}
+    spellDamageIncrease: 0
+    spellDamageCoefficient: 1
   handIndex: -1
   cardName: "\uB370\uBE44 \uC874\uC2A4"
   _cost: 5
@@ -109,6 +121,8 @@ MonoBehaviour:
     pieceColor: 1
     sprite: {fileID: 21300000, guid: 0c14240dd3c57de419141a3d11f52a24, type: 3}
   InfusedPiece: {fileID: 0}
+  increasedAD: 10
+  increasedHP: 10
 --- !u!114 &7886553202595520373
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_DonQuixote.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_DonQuixote.prefab
@@ -91,32 +91,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 0
-    soulOrbs: 10
-    soulEssence: 3
+    playerColor: 1
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
@@ -127,7 +109,7 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 2
   rarity: 1
-  description: "[\uB3CC\uC9C4] \uACF5\uACA9\uB825\uC774 70 \uC774\uC0C1\uC778 \uAE30\uBB3C\uC744
+  description: "\uACF5\uACA9\uB825\uC774 70 \uC774\uC0C1\uC778 \uAE30\uBB3C\uC744
     \uACF5\uACA9\uD560 \uB54C 40\uC758 \uCD94\uAC00 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: 5720266044062554583}
   isInSelection: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_GreenKnight.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_GreenKnight.prefab
@@ -82,30 +82,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 0
-    soulOrbs: 7
-    soulEssence: 7
+    playerColor: 1
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
+    deck: []
+    hand: []
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_GreenKnight.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_GreenKnight.prefab
@@ -80,14 +80,32 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8fbc851b057571d41a90090dc2bd6255, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  coordinate: {x: 0, y: 0}
   owner:
     playerColor: 0
-    soulOrbs: 0
-    soulEssence: 0
+    soulOrbs: 7
+    soulEssence: 7
     maxHandCardCount: 8
     mulliganHandCount: 4
-    deck: []
-    hand: []
+    isRevealed: 0
+    deck:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    hand:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
@@ -98,8 +116,9 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 2
   rarity: 2
-  description: "[\uB3C4\uBC1C]\n[\uAC15\uB9BC] \uAE30\uBB3C \uD558\uB098\uB97C \uC120\uD0DD\uD569\uB2C8\uB2E4.
-    \uADF8 \uAE30\uBB3C\uC774 \uC774 \uAE30\uBB3C\uC744 \uACF5\uACA9\uD569\uB2C8\uB2E4. "
+  description: "[\uBCF4\uD638\uB9C9]\n[\uAC15\uB9BC] \uAE30\uBB3C \uD558\uB098\uB97C
+    \uC120\uD0DD\uD569\uB2C8\uB2E4. \uADF8 \uAE30\uBB3C\uC774 \uC774 \uAE30\uBB3C\uC744
+    \uACF5\uACA9\uD569\uB2C8\uB2E4. "
   EffectOnCardUsed: {fileID: 7792896826575377344}
   isInSelection: 0
   pieceRestriction: 2
@@ -125,6 +144,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88847c76e1500604dbc58eba81655a39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  targetTypes: []
+  targetTypes:
+  - targetType: 0
+    targetPieceType: -1
+    isOpponent: 1
+    isFriendly: 1
+    targetTiles: 0
+    tileCoordinate: {x: 0, y: 0}
   isPositiveEffect: 0
   isNegativeEffect: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_JackFrost.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_JackFrost.prefab
@@ -91,15 +91,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 10
-    soulEssence: 10
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
     deck: []
     hand: []
-    deckPosition: {x: 7.6, y: -2.3}
+    deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_JackFrost.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_JackFrost.prefab
@@ -91,29 +91,30 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 0
-    soulOrbs: 0
-    soulEssence: 0
+    playerColor: 1
+    soulOrbs: 10
+    soulEssence: 10
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
     deck: []
     hand: []
-    deckPosition: {x: 0, y: 0}
+    deckPosition: {x: 7.6, y: -2.3}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
   cardName: "\uC7AD \uD504\uB85C\uC2A4\uD2B8"
-  _cost: 3
+  _cost: 6
   illustration: {fileID: 21300000, guid: 8902077ca8db70a48be98f62b1fd7bbd, type: 3}
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 2
   rarity: 1
-  description: "[\uAC15\uB9BC] \uBAA8\uB4E0 \uC801 \uAE30\uBB3C\uC744 \uAE30\uC808\uC2DC\uD0B5\uB2C8\uB2E4."
+  description: "[\uAC15\uB9BC] \uC801 \uAE30\uBB3C\uC744 \uD558\uB098 \uC120\uD0DD\uD558\uC5EC
+    \uAE30\uC808\uC2DC\uD0B5\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: 5943837467758970341}
   isInSelection: 0
   pieceRestriction: 5
-  _AD: 30
+  _AD: 45
   _HP: 20
   accessorySpriteList:
   - pieceType: 1
@@ -141,3 +142,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 193cb7bc1d75f024f9fd4b2d72e3a1d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  targetTypes:
+  - targetType: 0
+    targetPieceType: -1
+    isOpponent: 1
+    isFriendly: 0
+    targetTiles: 0
+    tileCoordinate: {x: 0, y: 0}
+  isPositiveEffect: 0
+  isNegativeEffect: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_KingArthur.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_KingArthur.prefab
@@ -80,7 +80,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 21d5a32beff23554bbe3cc4a013c6dca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isMine: 0
+  coordinate: {x: 0, y: 0}
+  owner:
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
+    maxHandCardCount: 8
+    mulliganHandCount: 4
+    isRevealed: 0
+    deck: []
+    hand: []
+    deckPosition: {x: 0, y: 0}
+    spellDamageIncrease: 0
+    spellDamageCoefficient: 1
   handIndex: -1
   cardName: "\uC544\uC11C\uC655"
   _cost: 10
@@ -104,6 +116,7 @@ MonoBehaviour:
     pieceColor: 1
     sprite: {fileID: 21300000, guid: de9530e6ad9979b4f8aeb2e78567b661, type: 3}
   InfusedPiece: {fileID: 0}
+  multipleAmount: 2
 --- !u!114 &2861086591322708584
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Merlin.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_Merlin.prefab
@@ -87,6 +87,7 @@ MonoBehaviour:
     soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
+    isRevealed: 0
     deck: []
     hand: []
     deckPosition: {x: 0, y: 0}
@@ -99,8 +100,8 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 2
   rarity: 2
-  description: "[\uAC15\uB9BC] \uB0B4 \uD328\uC5D0 \uC874\uC7AC\uD558\uB294 \uB9C8\uBC95\uC758
-    \uBE44\uC6A9\uC774 0\uC774 \uB429\uB2C8\uB2E4."
+  description: "\uC774 \uC601\uD63C\uC774 \uBD80\uC5EC\uB41C \uAE30\uBB3C\uC774 \uC0B4\uC544\uC788\uB294
+    \uB3D9\uC548 \uB0B4 \uB9C8\uBC95\uC758 \uBE44\uC6A9\uC774 1 \uAC10\uC18C\uD569\uB2C8\uB2E4."
   EffectOnCardUsed: {fileID: -8211901857969220769}
   isInSelection: 0
   pieceRestriction: 5
@@ -120,6 +121,7 @@ MonoBehaviour:
     pieceColor: 0
     sprite: {fileID: 21300000, guid: 6bcf0f8398d37f34494bea50cb1a449c, type: 3}
   InfusedPiece: {fileID: 0}
+  reductionCost: 1
 --- !u!114 &-8211901857969220769
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_MorganLeFay.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_MorganLeFay.prefab
@@ -85,7 +85,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e71d14047dc54d84aad316ac74428df9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isMine: 0
+  coordinate: {x: 0, y: 0}
+  owner:
+    playerColor: 0
+    soulOrbs: 0
+    soulEssence: 0
+    maxHandCardCount: 8
+    mulliganHandCount: 4
+    isRevealed: 0
+    deck: []
+    hand: []
+    deckPosition: {x: 0, y: 0}
+    spellDamageIncrease: 0
+    spellDamageCoefficient: 1
   handIndex: -1
   cardName: "\uBAA8\uB974\uAC74 \uB974 \uD398\uC774"
   _cost: 4

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_SolemnGardian.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_SolemnGardian.prefab
@@ -87,14 +87,23 @@ MonoBehaviour:
   coordinate: {x: 0, y: 0}
   owner:
     playerColor: 0
-    soulOrbs: 0
-    soulEssence: 0
+    soulOrbs: 10
+    soulEssence: 3
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
-    deck: []
-    hand: []
-    deckPosition: {x: 0, y: 0}
+    deck:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    hand:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    deckPosition: {x: 7.6, y: -2.3}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
@@ -104,7 +113,7 @@ MonoBehaviour:
   back: {fileID: 21300000, guid: c51ecb5accd89e146870565d08ab7610, type: 3}
   reigon: 2
   rarity: 0
-  description: "[\uBCF4\uD638\uB9C9]\n[\uB3C4\uBC1C]"
+  description: "[\uBCF4\uD638\uB9C9]"
   EffectOnCardUsed: {fileID: 6638018782557807443}
   isInSelection: 0
   pieceRestriction: 1

--- a/Assets/Prefabs/Game/Cards/Resources/Western/Soul_ToneDeafBard.prefab
+++ b/Assets/Prefabs/Game/Cards/Resources/Western/Soul_ToneDeafBard.prefab
@@ -91,18 +91,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   coordinate: {x: 0, y: 0}
   owner:
-    playerColor: 1
-    soulOrbs: 1
+    playerColor: 0
+    soulOrbs: 0
     soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
     isRevealed: 0
     deck: []
-    hand:
-    - {fileID: 0}
-    - {fileID: 0}
-    - {fileID: 0}
-    deckPosition: {x: 7.6, y: -2.3}
+    hand: []
+    deckPosition: {x: 0, y: 0}
     spellDamageIncrease: 0
     spellDamageCoefficient: 1
   handIndex: -1
@@ -148,3 +145,5 @@ MonoBehaviour:
   targetTypes: []
   isPositiveEffect: 1
   isNegativeEffect: 0
+  changeAD: -20
+  changeHP: 20

--- a/Assets/Prefabs/Game/Cards/SubCards/Spell_Thunder.prefab
+++ b/Assets/Prefabs/Game/Cards/SubCards/Spell_Thunder.prefab
@@ -88,6 +88,7 @@ MonoBehaviour:
     soulEssence: 0
     maxHandCardCount: 8
     mulliganHandCount: 4
+    isRevealed: 0
     deck: []
     hand: []
     deckPosition: {x: 0, y: 0}
@@ -126,4 +127,4 @@ MonoBehaviour:
     tileCoordinate: {x: 0, y: 0}
   isPositiveEffect: 0
   isNegativeEffect: 1
-  damage: 35
+  thunderDamage: 35

--- a/Assets/Prefabs/Game/ChessPieces/PieceEffectIcon.prefab
+++ b/Assets/Prefabs/Game/ChessPieces/PieceEffectIcon.prefab
@@ -100,12 +100,9 @@ MonoBehaviour:
   piece: {fileID: 0}
   sprites:
   - {fileID: 21300000, guid: 453c104ab80444045b461f5950466095, type: 3}
-  - {fileID: 21300000, guid: 5d7ad64d6f731fb4da0ba7d24b74f84f, type: 3}
   - {fileID: 21300000, guid: cd7ca212f0971a74695e293fc57c61f3, type: 3}
   - {fileID: 21300000, guid: 9888470f19ddabc46bade6d82c1b4d5e, type: 3}
-  - {fileID: 21300000, guid: 8ee2fce65f18720418136dbbdebb972e, type: 3}
   - {fileID: 21300000, guid: d9b31a2ea41077f4d8e2572f02d62855, type: 3}
   - {fileID: 21300000, guid: 1c33bde85a9789a488f1c0b6287687ca, type: 3}
-  - {fileID: 21300000, guid: 737cea1f324269549a660bbb8a3a4eed, type: 3}
   - {fileID: 21300000, guid: bfe97b61640822f4299b2121ddd63f00, type: 3}
   - {fileID: 21300000, guid: 15f9e5586cfa3354ab76f3dfdfcecadc, type: 3}

--- a/Assets/Script/Game/Card/Cards/Greek/HeavyArmoredInfantry.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/HeavyArmoredInfantry.cs
@@ -6,7 +6,7 @@ public class HeavyArmoredInfantry : SoulCard
 {
     protected override int CardID => cardIdDict["중기갑 보병"];
 
-    public int DefenseAmount = 5;
+    public int increasedHP = 5;
 
     protected override void Awake()
     {
@@ -15,12 +15,10 @@ public class HeavyArmoredInfantry : SoulCard
 
     public override void AddEffect()
     {
-        InfusedPiece.SetKeyword(Keyword.Type.Defense, DefenseAmount);
-        InfusedPiece.buff.AddBuffByValue(cardName, Buff.BuffType.Defense, DefenseAmount, true);
+        
     }
     public override void RemoveEffect()
     {
-        InfusedPiece.SetKeyword(Keyword.Type.Defense, -1 * DefenseAmount);
-        InfusedPiece.buff.TryRemoveSpecificBuff(cardName, Buff.BuffType.Defense);
+
     }
 }

--- a/Assets/Script/Game/Card/Cards/Greek/Hephaestus.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/Hephaestus.cs
@@ -1,58 +1,52 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class Hephaestus : SoulCard
 {
     protected override int CardID => cardIdDict["헤파이스토스"];
-
-    public int rangeDamage = 20;
+    private PlayerController playerController;
+    private int soulDamage = 10;
 
     protected override void Awake()
     {
         base.Awake();
     }
 
-    public void SoulEffect(Vector2Int coordinate)
+    public void AttackSoulPiece()
     {
-        List<Vector2Int> aroundCoordinates = new()
+        List<ChessPiece> enemyPieceList = GameBoard.instance.gameData.pieceObjects.Where(piece =>
+            piece.soul != null).ToList();
+
+        if (enemyPieceList.Count == 0)
+            return;
+        
+        foreach (var objPiece in enemyPieceList)
         {
-            coordinate + Vector2Int.up,
-            coordinate + Vector2Int.up + Vector2Int.right,
-            coordinate + Vector2Int.up + Vector2Int.left,
-            coordinate + Vector2Int.down,
-            coordinate + Vector2Int.down + Vector2Int.right,
-            coordinate + Vector2Int.down + Vector2Int.left,
-            coordinate + Vector2Int.right,
-            coordinate + Vector2Int.left,
-        };
-
-        GameData _chessData = GameBoard.instance.gameData;
-
-        for(int i = aroundCoordinates.Count - 1; i >= 0; i--)
-        {
-            Vector2Int currentCoordinate = aroundCoordinates[i];
-
-            if (!_chessData.IsValidCoordinate(currentCoordinate)) //잘못된 좌표면 제거
-            {
-                aroundCoordinates.RemoveAt(i);
-                continue;
-            }
-            if (_chessData.GetPiece(currentCoordinate) != null && _chessData.GetPiece(currentCoordinate) != InfusedPiece &&
-                _chessData.GetPiece(currentCoordinate).soul != null) //영혼에만 피해
-            {
-                _chessData.GetPiece(currentCoordinate).MinusHP(rangeDamage);
-            }
+            objPiece.MinusHP(soulDamage);
         }
     }
 
     public override void AddEffect()
     {
-        InfusedPiece.OnMove += SoulEffect;
+        if (InfusedPiece.pieceColor == GameBoard.PlayerColor.White)
+            playerController = GameBoard.instance.whiteController;
+        else
+            playerController = GameBoard.instance.blackController;
+
+        playerController.OnMyTurnEnd += AttackSoulPiece;
         InfusedPiece.OnSoulRemoved += RemoveEffect;
+        InfusedPiece.buff.AddBuffByDescription(cardName, Buff.BuffType.Description, "헤파이스토스: 내 턴이 끝날 때, 영혼이 부여된 모든 기물에게 "+ soulDamage +" 피해를 줍니다.", true);
     }
     public override void RemoveEffect()
     {
-        InfusedPiece.OnMove -= SoulEffect;
+        if (InfusedPiece.pieceColor == GameBoard.PlayerColor.White)
+            playerController = GameBoard.instance.whiteController;
+        else
+            playerController = GameBoard.instance.blackController;
+
+        playerController.OnMyTurnEnd -= AttackSoulPiece;
+        InfusedPiece.buff.TryRemoveSpecificBuff(cardName, Buff.BuffType.Description);
     }
 }

--- a/Assets/Script/Game/Card/Cards/Greek/Hercules.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/Hercules.cs
@@ -15,10 +15,6 @@ public class Hercules : SoulCard
 
     public override void AddEffect()
     {
-        InfusedPiece.SetKeyword(Keyword.Type.Taunt);
-        //버프 관련 변경 머지 후 추가예정
-        InfusedPiece.buff.AddBuffByKeyword(cardName, Buff.BuffType.Taunt);
-
         if (playercontroller == GameBoard.instance.CurrentPlayerController())
         {
             ADmultiply();
@@ -31,10 +27,6 @@ public class Hercules : SoulCard
 
     public override void RemoveEffect()
     {
-        InfusedPiece.SetKeyword(Keyword.Type.Taunt, 0);
-        //버프 관련 변경 머지 후 추가예정
-        InfusedPiece.buff.TryRemoveSpecificBuff(cardName, Buff.BuffType.Taunt);
-
         if (playercontroller == GameBoard.instance.CurrentPlayerController())
         {
             ADoriginate();

--- a/Assets/Script/Game/Card/Cards/Greek/NewScytheTank.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/NewScytheTank.cs
@@ -6,8 +6,6 @@ public class NewScytheTank : SoulCard
 {
     protected override int CardID => cardIdDict["신식-낫전차"];
 
-    public int defenseAmount = 10;
-
     protected override void Awake()
     {
         base.Awake();

--- a/Assets/Script/Game/Card/Cards/Greek/Typhon.cs
+++ b/Assets/Script/Game/Card/Cards/Greek/Typhon.cs
@@ -5,19 +5,44 @@ using UnityEngine;
 public class Typhon : SoulCard
 {
     protected override int CardID => cardIdDict["튀폰"];
+    private PlayerController playerController;
+    [SerializeField] private int countdown = 3;
 
     protected override void Awake()
     {
         base.Awake();
     }
 
+    private void KillCountDown()
+    {
+        countdown--;
+        Debug.Log(countdown);
+
+        if (countdown == 0)
+        {
+            InfusedPiece.Kill();
+        }
+    }
+
     public override void AddEffect()
     {
-        
+        if (InfusedPiece.pieceColor == GameBoard.PlayerColor.White)
+            playerController = GameBoard.instance.whiteController;
+        else
+            playerController = GameBoard.instance.blackController;
+
+        playerController.OnMyTurnStart += KillCountDown;
+        InfusedPiece.buff.AddBuffByDescription(cardName, Buff.BuffType.Description, "튀폰: 3턴 뒤, 이 기물은 파괴됩니다.", true);
     }
 
     public override void RemoveEffect()
     {
+        if (InfusedPiece.pieceColor == GameBoard.PlayerColor.White)
+            playerController = GameBoard.instance.whiteController;
+        else
+            playerController = GameBoard.instance.blackController;
 
+        playerController.OnMyTurnStart -= KillCountDown;
+        InfusedPiece.buff.TryRemoveSpecificBuff(cardName, Buff.BuffType.Description);
     }
 }

--- a/Assets/Script/Game/Card/Cards/Norse/Mimir.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Mimir.cs
@@ -53,7 +53,6 @@ public class Mimir : SoulCard
         }
         cardCostDict.Clear();
         playercolor.OnGetCard -= CardCostReduction;
-        InfusedPiece.OnSoulRemoved -= RemoveEffect;
     }
 
     public void CardCostReduction(Card card)

--- a/Assets/Script/Game/Card/Cards/Norse/Tyr.cs
+++ b/Assets/Script/Game/Card/Cards/Norse/Tyr.cs
@@ -1,32 +1,50 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class Tyr : SoulCard
 {
     protected override int CardID => Card.cardIdDict["티르"];
-    [HideInInspector] public ChessPiece restraint_target = null;
-    public int defenseQuantity = 10;
-
+    private PlayerController playerController;
     protected override void Awake()
     {
         base.Awake();
     }
 
+    private void StunRandomPiece()
+    {
+        List<ChessPiece> enemyPieceList = GameBoard.instance.gameData.pieceObjects.Where(piece => piece.pieceColor != InfusedPiece.pieceColor).ToList();
+
+        if (enemyPieceList.Count == 0)
+            return;
+
+        ChessPiece objectPiece = enemyPieceList[SynchronizedRandom.Range(0, enemyPieceList.Count)];
+
+        objectPiece.SetKeyword(Keyword.Type.Stun);
+        objectPiece.buff.AddBuffByKeyword(cardName, Buff.BuffType.Stun);
+    }
+
     public override void AddEffect()
     {
-        InfusedPiece.OnKilled += Restraint_remove;
+        if (InfusedPiece.pieceColor == GameBoard.PlayerColor.White)
+            playerController = GameBoard.instance.whiteController;
+        else
+            playerController = GameBoard.instance.blackController;
+
+        playerController.OnMyTurnEnd += StunRandomPiece;
         InfusedPiece.OnSoulRemoved += RemoveEffect;
+        InfusedPiece.buff.AddBuffByDescription(cardName, Buff.BuffType.Description, "티르: 내 턴이 끝날 때, 무작위 적 기물 하나를 기절시킵니다.", true);
     }
 
     public override void RemoveEffect()
     {
-        InfusedPiece.OnKilled -= Restraint_remove;
-        InfusedPiece.OnSoulRemoved -= RemoveEffect;
-    }
+        if (InfusedPiece.pieceColor == GameBoard.PlayerColor.White)
+            playerController = GameBoard.instance.whiteController;
+        else
+            playerController = GameBoard.instance.blackController;
 
-    public void Restraint_remove(ChessPiece chessPiece)
-    {
-        if (restraint_target != null) restraint_target.Unrestraint();
+        playerController.OnMyTurnEnd -= StunRandomPiece;
+        InfusedPiece.buff.TryRemoveSpecificBuff(cardName, Buff.BuffType.Description);
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
+++ b/Assets/Script/Game/Card/Cards/Western/DonQuixote.cs
@@ -14,14 +14,6 @@ public class DonQuixote : SoulCard
         base.Awake();
     }
 
-    public void InfuseEffect()
-    {
-        InfusedPiece.OnStartAttack += StartAttackEffect;
-        InfusedPiece.OnEndAttack += EndAttackEffect;
-
-        InfusedPiece.OnSoulRemoved += RemoveEffect;
-    }
-
     public void StartAttackEffect(ChessPiece chessPiece)
     {
         if (chessPiece.AD >= standardAD)
@@ -44,11 +36,13 @@ public class DonQuixote : SoulCard
     {
         InfusedPiece.OnStartAttack += StartAttackEffect;
         InfusedPiece.OnEndAttack += EndAttackEffect;
+        InfusedPiece.buff.AddBuffByDescription(cardName, Buff.BuffType.Description, "돈키호테: 공격력 " + standardAD + " 이상 기물 공격 시 " + extraAD + " 추가 피해", true);
     }
 
     public override void RemoveEffect()
     {
         InfusedPiece.OnStartAttack -= StartAttackEffect;
         InfusedPiece.OnEndAttack -= EndAttackEffect;
+        InfusedPiece.buff.TryRemoveSpecificBuff(cardName, Buff.BuffType.Description);
     }
 }

--- a/Assets/Script/Game/Card/Cards/Western/Merlin.cs
+++ b/Assets/Script/Game/Card/Cards/Western/Merlin.cs
@@ -1,11 +1,16 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using ExitGames.Client.Photon.StructWrapping;
+using Photon.Realtime;
 using UnityEngine;
 
 public class Merlin : SoulCard
 {
     protected override int CardID => Card.cardIdDict["멀린"];
+    PlayerData objectData;
+    public int reductionCost = 1;
+    Dictionary<Card, int> cardCostDict = new Dictionary<Card, int>();
 
     protected override void Awake()
     {
@@ -14,11 +19,63 @@ public class Merlin : SoulCard
 
     public override void AddEffect()
     {
-        
+        if (InfusedPiece.pieceColor == GameBoard.PlayerColor.White)
+            objectData = GameBoard.instance.gameData.playerWhite;
+        else
+            objectData = GameBoard.instance.gameData.playerBlack;
+
+        foreach (var card in objectData.hand)
+        {
+            if (card is SpellCard)
+            {
+                if (card.cost < reductionCost)
+                {
+                    cardCostDict.TryAdd(card, card.cost);
+                }
+                else
+                {
+                    card.cost -= reductionCost;
+                    cardCostDict.TryAdd(card, reductionCost);
+                } 
+            }
+        }
+
+        objectData.OnGetCard += CardCostReduction;
+        InfusedPiece.OnSoulRemoved += RemoveEffect;
+        InfusedPiece.buff.AddBuffByDescription(cardName, Buff.BuffType.Description, "멀린: 이 영혼이 부여된 기물이 살아있는 동안 내 마법의 비용이 "+ reductionCost + " 감소합니다.", true);
     }
 
     public override void RemoveEffect()
     {
+        foreach (var card in objectData.hand)
+        {
+            if (cardCostDict.ContainsKey(card))
+            {
+                card.cost += cardCostDict[card];
+            }
+            else
+            {
+                card.cost += reductionCost;
+            }
+        }
+        cardCostDict.Clear();
+        objectData.OnGetCard -= CardCostReduction;
+        InfusedPiece.buff.TryRemoveSpecificBuff(cardName, Buff.BuffType.Description);
+    }
 
+    public void CardCostReduction(Card card)
+    {
+        if (card is SpellCard)
+        {
+            if (card.cost < reductionCost)
+            {
+                cardCostDict.TryAdd(card, card.cost);
+            }
+            else
+            {
+                card.cost -= reductionCost;
+                cardCostDict.TryAdd(card, reductionCost);
+            } 
+        }
     }
 }

--- a/Assets/Script/Game/ChessPieces/Bishop.cs
+++ b/Assets/Script/Game/ChessPieces/Bishop.cs
@@ -8,7 +8,7 @@ public class Bishop : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
-        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+        if (GetKeyword(Keyword.Type.Stun) == 1 /* || GetKeyword(Keyword.Type.Restraint) == 1  */|| isSoulSet) return movableCoordinates;
 
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;

--- a/Assets/Script/Game/ChessPieces/ChessPiece.cs
+++ b/Assets/Script/Game/ChessPieces/ChessPiece.cs
@@ -57,12 +57,12 @@ abstract public class ChessPiece : TargetableObject
 
     // 키워드 우선순위: 면역, 도발, 보호막, 방어력
     // isTauntAttack은 도발이 연쇄적으로 작동하지 않도록 함
-    public void MinusHP(int value, bool isTauntAttack = false)
+    public void MinusHP(int value/* , bool isTauntAttack = false */)
     {
         if (GetKeyword(Keyword.Type.Immunity) == 1)
             return;
 
-        if (!isTauntAttack)
+        /* if (!isTauntAttack)
         {
             ChessPiece tauntPiece = GetTauntPieceAround();
             if (tauntPiece != null)
@@ -70,7 +70,7 @@ abstract public class ChessPiece : TargetableObject
                 tauntPiece.MinusHP(value, true);
                 return;
             }
-        }
+        } */
 
         if (GetKeyword(Keyword.Type.Shield) == 1)
         {
@@ -79,12 +79,12 @@ abstract public class ChessPiece : TargetableObject
             return;
         }
 
-        if (GetKeyword(Keyword.Type.Defense) > 0)
+        /* if (GetKeyword(Keyword.Type.Defense) > 0)
         {
             if (value < GetKeyword(Keyword.Type.Defense))       //피해량보다 방어력이 클 경우
                 return;
             value -= keywordDictionary[Keyword.Type.Defense];
-        }
+        } */
 
         //피격 이펙트
         PieceEffectIcon attackedEffect = Instantiate(effectIconPrefab, transform.position, Quaternion.identity);
@@ -335,10 +335,10 @@ abstract public class ChessPiece : TargetableObject
         maxHP += soul.HP;
         AD += soul.AD;
 
-        if (GetKeyword(Keyword.Type.Restraint) == 1)            // 구속된 기물의 영혼 교체할 때 구속 유지
+        /* if (GetKeyword(Keyword.Type.Restraint) == 1)            // 구속된 기물의 영혼 교체할 때 구속 유지
         {
             soul.RemoveEffect();
-        }
+        } */
     }
 
     public void RemoveSoul()
@@ -374,45 +374,45 @@ abstract public class ChessPiece : TargetableObject
     public void SetKeyword(Keyword.Type keywordType, int n = 1)
     {
         int oldKeyword = GetKeyword(keywordType);
-        if (keywordType == Keyword.Type.Defense)
+        /* if (keywordType == Keyword.Type.Defense)
             keywordDictionary[keywordType] += n;
-        else
-            keywordDictionary[keywordType] = n;
+        else */
+        keywordDictionary[keywordType] = n;
 
         //버프 및 디버프 아이콘 스프라이트 설정 (우선순위는 Enum 값이 작을수록 높음)
         effectIcon.SetIconSprite();
 
-        if (keywordType == Keyword.Type.Taunt && n == 1)
+        /* if (keywordType == Keyword.Type.Taunt && n == 1)
         {
             _tauntNumber = GameBoard.instance.gameData.tauntNumber;          //도발 부여 순서 저장
         }
-        else if (keywordType == Keyword.Type.Stun && n == 1)
+        else */ if (keywordType == Keyword.Type.Stun && n == 1)
         {
             //효과 발동 시점의 색깔 턴이 한번 더 돌아와야 스턴 해제
             GameBoard.instance.whiteController.OnMyTurnStart -= Unstun; //이미 있는 스턴 덮어씌우기
             GameBoard.instance.blackController.OnMyTurnStart -= Unstun;
             GameBoard.instance.CurrentPlayerController().OnMyTurnStart += Unstun;
         }
-        else if (keywordType == Keyword.Type.Restraint && n == 1)
+        /* else if (keywordType == Keyword.Type.Restraint && n == 1)
         {
             if (soul != null && oldKeyword != 1) //구속 풀리기 전에 다시 구속되면 RemoveEffect가 2번 실행되는 버그 수정
             {
                 if (GetKeyword(Keyword.Type.Silence) != 1) //침묵 상태에서 구속될 때 RemoveEffect가 2번 실행되는 버그 수정
                     soul.RemoveEffect();
             }
-        }
+        } */
         else if (keywordType == Keyword.Type.Silence && n == 1)
         {
             if (soul != null)
             {
-                if (oldKeyword != 1 && GetKeyword(Keyword.Type.Restraint) != 1) soul.RemoveEffect(); //침묵,구속 풀리기 전에 다시 침묵되면 RemoveEffect 2번 실행 버그 수정
+                if (oldKeyword != 1/*  && GetKeyword(Keyword.Type.Restraint) != 1 */) soul.RemoveEffect(); //침묵,구속 풀리기 전에 다시 침묵되면 RemoveEffect 2번 실행 버그 수정
                 RemoveBuff();
             }
         }
-        else if (keywordType == Keyword.Type.Rush && n == 1)
+        /* else if (keywordType == Keyword.Type.Rush && n == 1)
         {
             MakeIsSoulSetFalse();
-        }
+        } */
     }
 
     public int GetKeyword(Keyword.Type keywordType) => keywordDictionary[keywordType];
@@ -442,7 +442,7 @@ abstract public class ChessPiece : TargetableObject
         GameBoard.instance.CurrentPlayerController().OnMyTurnStart -= Unstun;
     }
 
-    // 구속 해제
+    /* // 구속 해제
     public void Unrestraint()
     {
         SetKeyword(Keyword.Type.Restraint, 0);
@@ -451,9 +451,9 @@ abstract public class ChessPiece : TargetableObject
         {
             soul.AddEffect();
         }
-    }
+    } */
 
-    private ChessPiece GetTauntPieceAround()
+    /* private ChessPiece GetTauntPieceAround()
     {
         List<Vector2Int> aroundCoordinates = new()
         {
@@ -517,7 +517,7 @@ abstract public class ChessPiece : TargetableObject
 
             return tauntPiece;
         }
-    }
+    } */
 
     public void RemoveBuff()        // RemoveSoul과 침묵 키워드에서만 호출
     {
@@ -544,18 +544,18 @@ abstract public class ChessPiece : TargetableObject
                 moveCount -= buffInfo.value;
                 if (moveCount < 1) moveCount = 0;
             }
-            else if (buffType == Buff.BuffType.Defense)
+            /* else if (buffType == Buff.BuffType.Defense)
             {
                 SetKeyword(Keyword.Type.Defense, -buffInfo.value);
-            }
+            } */
             else if (buffType == Buff.BuffType.Immunity)
             {
                 SetKeyword(Keyword.Type.Immunity, 0);
             }
-            else if (buffType == Buff.BuffType.Taunt)
+            /* else if (buffType == Buff.BuffType.Taunt)
             {
                 SetKeyword(Keyword.Type.Taunt, 0);
-            }
+            } */
             else if (buffType == Buff.BuffType.Shield)
             {
                 SetKeyword(Keyword.Type.Shield, 0);
@@ -564,10 +564,10 @@ abstract public class ChessPiece : TargetableObject
             {
                 SetKeyword(Keyword.Type.Stun, 0);
             }
-            else if (buffType == Buff.BuffType.Restraint)
+            /* else if (buffType == Buff.BuffType.Restraint)
             {
                 SetKeyword(Keyword.Type.Restraint, 0);
-            }
+            } */
             else if (buffType == Buff.BuffType.Stealth)
             {
                 SetKeyword(Keyword.Type.Stealth, 0);
@@ -576,10 +576,10 @@ abstract public class ChessPiece : TargetableObject
             {
                 SetKeyword(Keyword.Type.Silence, 0);
             }
-            else if (buffType == Buff.BuffType.Rush)
+            /* else if (buffType == Buff.BuffType.Rush)
             {
                 SetKeyword(Keyword.Type.Rush, 0);
-            }
+            } */
 
             // buffType == Buff.BuffType.Description인 경우는 OnSoulRemoved 통해 구현
         }

--- a/Assets/Script/Game/ChessPieces/King.cs
+++ b/Assets/Script/Game/ChessPieces/King.cs
@@ -10,7 +10,7 @@ public class King : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
-        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+        if (GetKeyword(Keyword.Type.Stun) == 1 /* || GetKeyword(Keyword.Type.Restraint) == 1 */ || isSoulSet) return movableCoordinates;
 
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;

--- a/Assets/Script/Game/ChessPieces/Knight.cs
+++ b/Assets/Script/Game/ChessPieces/Knight.cs
@@ -8,7 +8,7 @@ public class Knight : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
-        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+        if (GetKeyword(Keyword.Type.Stun) == 1 /* || GetKeyword(Keyword.Type.Restraint) == 1 */ || isSoulSet) return movableCoordinates;
 
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;

--- a/Assets/Script/Game/ChessPieces/Pawn.cs
+++ b/Assets/Script/Game/ChessPieces/Pawn.cs
@@ -9,7 +9,7 @@ public class Pawn : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
-        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+        if (GetKeyword(Keyword.Type.Stun) == 1 /* || GetKeyword(Keyword.Type.Restraint) == 1  */|| isSoulSet) return movableCoordinates;
 
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;

--- a/Assets/Script/Game/ChessPieces/PieceEffectIcon.cs
+++ b/Assets/Script/Game/ChessPieces/PieceEffectIcon.cs
@@ -21,9 +21,9 @@ public class PieceEffectIcon : MonoBehaviour
     {
         foreach (Keyword.Type i in Enum.GetValues(typeof(Keyword.Type)))
         {
-            if ((i != Keyword.Type.Defense) && (piece.GetKeyword(i) > 0))
+            if (/* (i != Keyword.Type.Defense) &&  */piece.GetKeyword(i) > 0)
             {
-                spriteRenderer.sprite = sprites[(int)i - 1];
+                spriteRenderer.sprite = sprites[(int)i];
                 return;
             }
         }
@@ -32,13 +32,13 @@ public class PieceEffectIcon : MonoBehaviour
 
     public void AttackedEffect()
     {
-        spriteRenderer.sprite = sprites[8];
+        spriteRenderer.sprite = sprites[5];
         Invoke("DestroyIcon", 0.4f);
     }
 
     public void MoveRestrictionEffect()
     {
-        spriteRenderer.sprite = sprites[9];
+        spriteRenderer.sprite = sprites[6];
     }
 
     public void DestroyIcon()

--- a/Assets/Script/Game/ChessPieces/Quene.cs
+++ b/Assets/Script/Game/ChessPieces/Quene.cs
@@ -9,7 +9,7 @@ public class Quene : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
-        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+        if (GetKeyword(Keyword.Type.Stun) == 1 /* || GetKeyword(Keyword.Type.Restraint) == 1  */|| isSoulSet) return movableCoordinates;
 
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;

--- a/Assets/Script/Game/ChessPieces/Rook.cs
+++ b/Assets/Script/Game/ChessPieces/Rook.cs
@@ -9,7 +9,7 @@ public class Rook : ChessPiece
     {
         List<Vector2Int> movableCoordinates = new List<Vector2Int>();
 
-        if (GetKeyword(Keyword.Type.Stun) == 1 || GetKeyword(Keyword.Type.Restraint) == 1 || isSoulSet) return movableCoordinates;
+        if (GetKeyword(Keyword.Type.Stun) == 1 /* || GetKeyword(Keyword.Type.Restraint) == 1 */ || isSoulSet) return movableCoordinates;
 
         ChessPiece blockingPiece;
         Vector2Int targetCoordinate;

--- a/Assets/Script/Game/Effects/Keyword.cs
+++ b/Assets/Script/Game/Effects/Keyword.cs
@@ -8,15 +8,15 @@ public class Keyword : Effect
 {
     public enum Type
     {
-        Defense,        // 방어력
+        /* Defense, */        // 방어력
         Immunity,       // 면역
-        Taunt,          // 도발
+        /* Taunt, */          // 도발
         Shield,         // 보호막
         Stun,           // 기절
-        Restraint,      // 구속
+        /* Restraint, */      // 구속
         Stealth,        // 은신
         Silence,        // 침묵
-        Rush            // 돌진
+        /* Rush */            // 돌진
     }
 
     public static Type[] AllKeywords { get => Enum.GetValues(typeof(Type)).Cast<Type>().ToArray(); }

--- a/Assets/Script/Game/Effects/SoulEffect/Greek/ApollonEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Greek/ApollonEffect.cs
@@ -6,37 +6,34 @@ public class ApollonEffect : Effect
 {
     public override void EffectAction(PlayerController player)
     {
-        Apollon apollon_component = gameObject.GetComponent<Apollon>();
-        Vector2Int StandardPosition = apollon_component.InfusedPiece.coordinate;
-        List<Vector2Int> row = new List<Vector2Int>();
+        Apollon apollonComponent = gameObject.GetComponent<Apollon>();
+        Vector2Int StandardPosition = apollonComponent.InfusedPiece.coordinate;
 
-        Vector2Int TempPosition = StandardPosition;
-        TempPosition += Vector2Int.left;
-        while (GameBoard.instance.gameData.IsValidCoordinate(TempPosition))
+        Vector2Int tempPosition = StandardPosition;
+        tempPosition += Vector2Int.left;
+        if (GameBoard.instance.gameData.IsValidCoordinate(tempPosition))
         {
-            row.Add(TempPosition);
-            TempPosition += Vector2Int.left;
-        }
-
-        TempPosition = StandardPosition;
-        TempPosition += Vector2Int.right;
-        while (GameBoard.instance.gameData.IsValidCoordinate(TempPosition))
-        {
-            row.Add(TempPosition);
-            TempPosition += Vector2Int.right;
-        }
-
-        foreach (var position in row) //행의 모든 내 기물에게 보호막
-        {
-            ChessPiece obj = GameBoard.instance.gameData.GetPiece(position);
-            if (obj != null && obj.pieceColor == player.playerColor)
+            ChessPiece objPiece = GameBoard.instance.gameData.GetPiece(tempPosition);
+            if (objPiece != null && objPiece.pieceColor == player.playerColor)
             {
-                obj.SetKeyword(Keyword.Type.Shield);
-                //버프 관련 변경 머지 후 버프 추가
-                obj.buff.AddBuffByKeyword(apollon_component.cardName, Buff.BuffType.Shield);
+                objPiece.SetKeyword(Keyword.Type.Shield);
+                objPiece.buff.AddBuffByKeyword(apollonComponent.cardName, Buff.BuffType.Shield);
             }
         }
-        apollon_component.InfusedPiece.SetKeyword(Keyword.Type.Shield); //자신에게 보호막
-        apollon_component.InfusedPiece.buff.AddBuffByKeyword(apollon_component.cardName, Buff.BuffType.Shield);
+
+        tempPosition = StandardPosition;
+        tempPosition += Vector2Int.right;
+        if (GameBoard.instance.gameData.IsValidCoordinate(tempPosition))
+        {
+            ChessPiece objPiece = GameBoard.instance.gameData.GetPiece(tempPosition);
+            if (objPiece != null && objPiece.pieceColor == player.playerColor)
+            {
+                objPiece.SetKeyword(Keyword.Type.Shield);
+                objPiece.buff.AddBuffByKeyword(apollonComponent.cardName, Buff.BuffType.Shield);
+            }
+        }
+
+        apollonComponent.InfusedPiece.SetKeyword(Keyword.Type.Shield); //자신에게 보호막
+        apollonComponent.InfusedPiece.buff.AddBuffByKeyword(apollonComponent.cardName, Buff.BuffType.Shield);
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Greek/HeavyArmoredInfantryEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Greek/HeavyArmoredInfantryEffect.cs
@@ -7,9 +7,31 @@ public class HeavyArmoredInfantryEffect : Effect
 {
     public override void EffectAction(PlayerController player)
     {
-        HeavyArmoredInfantry HeavyArmoredInfantryComponent = gameObject.GetComponent<HeavyArmoredInfantry>();
+        HeavyArmoredInfantry heavyArmoredInfantryComponent = gameObject.GetComponent<HeavyArmoredInfantry>();
+        Vector2Int StandardPosition = heavyArmoredInfantryComponent.InfusedPiece.coordinate;
 
-        HeavyArmoredInfantryComponent.InfusedPiece.SetKeyword(Keyword.Type.Defense, HeavyArmoredInfantryComponent.DefenseAmount);
-        HeavyArmoredInfantryComponent.InfusedPiece.buff.AddBuffByValue(HeavyArmoredInfantryComponent.cardName, Buff.BuffType.Defense, HeavyArmoredInfantryComponent.DefenseAmount, true);
+        Vector2Int tempPosition = StandardPosition;
+        tempPosition += Vector2Int.left;
+        if (GameBoard.instance.gameData.IsValidCoordinate(tempPosition))
+        {
+            ChessPiece objPiece = GameBoard.instance.gameData.GetPiece(tempPosition);
+            if (objPiece != null && objPiece.pieceColor == player.playerColor)
+            {
+                objPiece.maxHP += heavyArmoredInfantryComponent.increasedHP;
+                objPiece.buff.AddBuffByValue(heavyArmoredInfantryComponent.cardName, Buff.BuffType.HP, heavyArmoredInfantryComponent.increasedHP, false);
+            }
+        }
+
+        tempPosition = StandardPosition;
+        tempPosition += Vector2Int.right;
+        if (GameBoard.instance.gameData.IsValidCoordinate(tempPosition))
+        {
+            ChessPiece objPiece = GameBoard.instance.gameData.GetPiece(tempPosition);
+            if (objPiece != null && objPiece.pieceColor == player.playerColor)
+            {
+                objPiece.maxHP += heavyArmoredInfantryComponent.increasedHP;
+                objPiece.buff.AddBuffByValue(heavyArmoredInfantryComponent.cardName, Buff.BuffType.HP, heavyArmoredInfantryComponent.increasedHP, false);
+            }
+        }
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Greek/HephaestusEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Greek/HephaestusEffect.cs
@@ -9,13 +9,5 @@ public class HephaestusEffect : Effect
         Hephaestus HephaestusComponent = gameObject.GetComponent<Hephaestus>();
 
         HephaestusComponent.AddEffect();
-
-        HephaestusComponent.InfusedPiece.buff.AddBuffByDescription(HephaestusComponent.cardName, Buff.BuffType.Description, "헤파이스토스: 이동 후 주위의 모든 영혼이 깃든 기물에게 " + HephaestusComponent.rangeDamage + " 피해", true);
-        HephaestusComponent.InfusedPiece.OnSoulRemoved += RemoveBuffInfo;
-    }
-
-    public void RemoveBuffInfo()
-    {
-        gameObject.GetComponent<SoulCard>().InfusedPiece.buff.TryRemoveSpecificBuff(gameObject.GetComponent<SoulCard>().cardName, Buff.BuffType.Description);
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Greek/HerculesEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Greek/HerculesEffect.cs
@@ -9,7 +9,7 @@ public class HerculesEffect : Effect
         Hercules herculesComponent = gameObject.GetComponent<Hercules>();
         herculesComponent.playercontroller = player;
 
-        herculesComponent.InfusedPiece.buff.AddBuffByDescription(herculesComponent.cardName, Buff.BuffType.Description, "헤라클레스: 본인 턴 동안 공격력 " + herculesComponent.multipleAD +"배", true);
+        herculesComponent.InfusedPiece.buff.AddBuffByDescription(herculesComponent.cardName, Buff.BuffType.Description, "헤라클레스: 내 턴 동안 공격력 " + herculesComponent.multipleAD +"배", true);
         herculesComponent.AddEffect();
         
         herculesComponent.InfusedPiece.OnSoulRemoved += RemoveBuffInfo;

--- a/Assets/Script/Game/Effects/SoulEffect/Greek/NewScytheTankEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Greek/NewScytheTankEffect.cs
@@ -8,10 +8,7 @@ public class NewScytheTankEffect : Effect
     {
         NewScytheTank newScytheTankComponent = gameObject.GetComponent<NewScytheTank>();
 
-        newScytheTankComponent.InfusedPiece.SetKeyword(Keyword.Type.Defense, newScytheTankComponent.defenseAmount);
-        newScytheTankComponent.InfusedPiece.SetKeyword(Keyword.Type.Rush);
-
-        newScytheTankComponent.InfusedPiece.buff.AddBuffByValue(newScytheTankComponent.cardName, Buff.BuffType.Defense, newScytheTankComponent.defenseAmount, true);
-        newScytheTankComponent.InfusedPiece.buff.AddBuffByKeyword(newScytheTankComponent.cardName, Buff.BuffType.Rush);
+        newScytheTankComponent.InfusedPiece.SetKeyword(Keyword.Type.Shield);
+        newScytheTankComponent.InfusedPiece.buff.AddBuffByKeyword(newScytheTankComponent.cardName, Buff.BuffType.Shield);
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Greek/TyphonEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Greek/TyphonEffect.cs
@@ -18,5 +18,7 @@ public class TyphonEffect : Effect
             GameBoard.instance.gameData.playerBlack.RemoveHandCards();
             GameBoard.instance.gameData.playerBlack.RemoveDeckCards();
         }
+        
+        gameObject.GetComponent<Typhon>().AddEffect();
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Norse/TyrEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Norse/TyrEffect.cs
@@ -2,27 +2,12 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class TyrEffect : TargetingEffect
+public class TyrEffect : Effect
 {
     public override void EffectAction(PlayerController player)
     {
         Tyr tyrComponent = gameObject.GetComponent<Tyr>();
 
-        foreach (var target in targets)
-        {
-            tyrComponent.restraint_target = target as ChessPiece;
-        }
-        tyrComponent.restraint_target.SetKeyword(Keyword.Type.Restraint);
-        //버프 관련 변경 머지 후 버프 추가
-        tyrComponent.restraint_target.buff.AddBuffByKeyword(tyrComponent.cardName, Buff.BuffType.Restraint);
-
         tyrComponent.AddEffect();
-        tyrComponent.InfusedPiece.OnSoulRemoved += tyrComponent.RemoveEffect;
-
-        tyrComponent.InfusedPiece.SetKeyword(Keyword.Type.Taunt);
-        tyrComponent.InfusedPiece.SetKeyword(Keyword.Type.Defense, tyrComponent.defenseQuantity);
-        //버프 관련 변경 머지 후 버프 추가
-        tyrComponent.InfusedPiece.buff.AddBuffByKeyword(tyrComponent.cardName, Buff.BuffType.Taunt);
-        tyrComponent.InfusedPiece.buff.AddBuffByValue(tyrComponent.cardName, Buff.BuffType.Defense, tyrComponent.defenseQuantity, true);
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/SubCards/ThunderEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/SubCards/ThunderEffect.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 public class ThunderEffect : TargetingEffect
 {
-    [SerializeField] private int thunderDamage;
+    [SerializeField] private int thunderDamage = 35;
     private void Awake()
     {
         if (GameBoard.instance.playerColor == GameBoard.PlayerColor.White)

--- a/Assets/Script/Game/Effects/SoulEffect/Western/DonQuixoteEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Western/DonQuixoteEffect.cs
@@ -8,16 +8,7 @@ public class DonQuixoteEffect : Effect
     {
         DonQuixote donQuixoteComponent = gameObject.GetComponent<DonQuixote>();
 
-        donQuixoteComponent.InfusedPiece.SetKeyword(Keyword.Type.Rush);
-        donQuixoteComponent.InfusedPiece.buff.AddBuffByKeyword(donQuixoteComponent.cardName, Buff.BuffType.Rush);
-
-        donQuixoteComponent.InfusedPiece.buff.AddBuffByDescription(donQuixoteComponent.cardName, Buff.BuffType.Description, "돈키호테: 공격력 " + donQuixoteComponent.standardAD + " 이상 기물 공격 시 " + donQuixoteComponent.extraAD + " 추가 피해", true);
-        donQuixoteComponent.InfuseEffect();
-        donQuixoteComponent.InfusedPiece.OnSoulRemoved += RemoveBuffInfo;
-    }
-
-    public void RemoveBuffInfo()
-    {
-        gameObject.GetComponent<DonQuixote>().InfusedPiece.buff.TryRemoveSpecificBuff(gameObject.GetComponent<DonQuixote>().cardName, Buff.BuffType.Description);
+        donQuixoteComponent.AddEffect();
+        donQuixoteComponent.InfusedPiece.OnSoulRemoved += donQuixoteComponent.RemoveEffect;
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Western/GreenKnightEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Western/GreenKnightEffect.cs
@@ -5,32 +5,16 @@ using UnityEngine;
 
 public class GreenKnightEffect : TargetingEffect
 {
-     ChessPiece.PieceType targetPieceRestriction =
-        ChessPiece.PieceType.Pawn |
-        ChessPiece.PieceType.Knight |
-        ChessPiece.PieceType.Bishop |
-        ChessPiece.PieceType.Rook |
-        ChessPiece.PieceType.Quene |
-        ChessPiece.PieceType.King;
-
-    SoulCard soul = null;
-
-    void Awake()
-    {
-        if (soul == null) soul = gameObject.GetComponent<SoulCard>();
-        Predicate<ChessPiece> condition = (ChessPiece piece) => piece != soul.InfusedPiece;
-        EffectTarget effectTarget = new EffectTarget(TargetType.Piece, targetPieceRestriction , true, true, condition);
-        targetTypes.Add(effectTarget);
-    }
-
     public override void EffectAction(PlayerController player)
     {
-        gameObject.GetComponent<SoulCard>().InfusedPiece.SetKeyword(Keyword.Type.Taunt);
-        gameObject.GetComponent<SoulCard>().InfusedPiece.buff.AddBuffByKeyword(gameObject.GetComponent<SoulCard>().cardName, Buff.BuffType.Taunt);
+        GreenKnight greenKnightComponent = gameObject.GetComponent<GreenKnight>();
+
+        greenKnightComponent.InfusedPiece.SetKeyword(Keyword.Type.Shield);
+        greenKnightComponent.InfusedPiece.buff.AddBuffByKeyword(greenKnightComponent.cardName, Buff.BuffType.Shield);
 
         foreach (var target in targets)
         {
-            (target as ChessPiece).Attack(gameObject.GetComponent<SoulCard>().InfusedPiece);
+            (target as ChessPiece).Attack(greenKnightComponent.InfusedPiece);
         }
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Western/JackFrostEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Western/JackFrostEffect.cs
@@ -3,16 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-public class JackFrostEffect : Effect
+public class JackFrostEffect : TargetingEffect
 {
     public override void EffectAction(PlayerController player)
     {
-        List<ChessPiece> enemyPieceList = GameBoard.instance.gameData.pieceObjects.Where(piece => piece.pieceColor != player.playerColor).ToList();
+        JackFrost jackFrostComponent = gameObject.GetComponent<JackFrost>();
 
-        foreach (ChessPiece piece in enemyPieceList)
+        foreach (var target in targets)
         {
-            piece.SetKeyword(Keyword.Type.Stun);
-            piece.buff.AddBuffByKeyword(gameObject.GetComponent<SoulCard>().cardName, Buff.BuffType.Stun);
+            (target as ChessPiece).SetKeyword(Keyword.Type.Stun);
+            (target as ChessPiece).buff.AddBuffByKeyword(jackFrostComponent.cardName, Buff.BuffType.Stun);
         }
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Western/MerlinEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Western/MerlinEffect.cs
@@ -5,21 +5,8 @@ using System.Linq;
 
 public class MerlinEffect : Effect
 {
-    public int cost = 0;
-
     public override void EffectAction(PlayerController player)
     {
-        PlayerData playerData = null;
-        if (player.playerColor == GameBoard.PlayerColor.White)
-            playerData = GameBoard.instance.gameData.playerWhite;
-        else
-            playerData = GameBoard.instance.gameData.playerBlack;      
-
-        List<Card> ourSpellCards = playerData.hand.Where(card => card.GetComponent<SpellCard>() != null).ToList();
-
-        foreach (var card in ourSpellCards)
-        {
-            card.cost = cost;
-        }
+        gameObject.GetComponent<Merlin>().AddEffect();
     }
 }

--- a/Assets/Script/Game/Effects/SoulEffect/Western/SolemnGuardianEffect.cs
+++ b/Assets/Script/Game/Effects/SoulEffect/Western/SolemnGuardianEffect.cs
@@ -7,10 +7,9 @@ public class SolemnGuardianEffect : Effect
 {
     public override void EffectAction(PlayerController player)
     {
-        gameObject.GetComponent<SoulCard>().InfusedPiece.SetKeyword(Keyword.Type.Shield);
-        gameObject.GetComponent<SoulCard>().InfusedPiece.SetKeyword(Keyword.Type.Taunt);
+        SolemnGuardian solemnGuardianComponent = gameObject.GetComponent<SolemnGuardian>();
 
-        gameObject.GetComponent<SoulCard>().InfusedPiece.buff.AddBuffByKeyword(gameObject.GetComponent<SoulCard>().cardName, Buff.BuffType.Shield);
-        gameObject.GetComponent<SoulCard>().InfusedPiece.buff.AddBuffByKeyword(gameObject.GetComponent<SoulCard>().cardName, Buff.BuffType.Taunt);
+        solemnGuardianComponent.InfusedPiece.SetKeyword(Keyword.Type.Shield);
+        solemnGuardianComponent.InfusedPiece.buff.AddBuffByKeyword(solemnGuardianComponent.cardName, Buff.BuffType.Shield);
     }
 }

--- a/Assets/Script/UI/LocalController.cs
+++ b/Assets/Script/UI/LocalController.cs
@@ -75,11 +75,11 @@ public class LocalController : MonoBehaviour, IPointerClickHandler
         {
             spriteRenderer.sprite = blackButton;
 
-            whiteController.enabled = false;
-            blackController.enabled = true;
-
             whiteController.TurnEnd();
             blackController.OpponentTurnEnd();
+
+            whiteController.enabled = false;
+            blackController.enabled = true;
             
             if (GameBoard.instance.playerColor == GameBoard.PlayerColor.White)
                 turn_display.GetComponentInChildren<TextMeshProUGUI>().text = "상대의 턴";
@@ -97,11 +97,11 @@ public class LocalController : MonoBehaviour, IPointerClickHandler
         {
             spriteRenderer.sprite = whiteButton;
 
-            blackController.enabled = false;
-            whiteController.enabled = true;
-
             blackController.TurnEnd();
             whiteController.OpponentTurnEnd();
+            
+            blackController.enabled = false;
+            whiteController.enabled = true;
 
             if (GameBoard.instance.playerColor == GameBoard.PlayerColor.White)
                 turn_display.GetComponentInChildren<TextMeshProUGUI>().text = "당신의 턴";


### PR DESCRIPTION
티르/우트가르다 로키/헤파이스토스/아폴론/헤라클레스/튀폰/중기갑 보병/신식 낫전차/녹색 기사/잭 프로스트/멀린 카드를 리워크에 따라 변경하였습니다.
턴 종료가 되기 전, 활성화된 컨트롤러가 먼저 변경되는 버그를 수정하였습니다.
키워드 삭제에 따른 근엄한 경비병/돈키호테 카드를 수정하였습니다.
버그가 존재하는 카드를 수정하였습니다.