### PR TITLE
수르트 재구현 / 티타노 마키아 재수정 / 버그 수정 / 카드 위치 조정 예외처리

### DIFF
--- a/Assets/Script/Game/ChessBoard.cs
+++ b/Assets/Script/Game/ChessBoard.cs
@@ -565,7 +565,7 @@ public class ChessBoard : MonoBehaviour
         for (int i = 0; i < repeat; i++)
         {
             titanomachiaSequence.Append(titanoKillEffect());
-            titanomachiaSequence.AppendInterval(0.2f);
+            titanomachiaSequence.AppendInterval(0.8f);
         }
         
         titanomachiaSequence.Append(FadeOutTween());

--- a/Assets/Script/Game/Effects/Norse/SurtrEffect.cs
+++ b/Assets/Script/Game/Effects/Norse/SurtrEffect.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class SurtrEffect : Effect
@@ -10,18 +11,33 @@ public class SurtrEffect : Effect
         GameBoard.instance.whiteController.OnMyTurnEnd -= surtrComponent.DecreaseCost;
         GameBoard.instance.blackController.OnMyTurnEnd -= surtrComponent.DecreaseCost;
 
-        GameBoard.instance.gameData.playerWhite.RemoveHandCards();
-        GameBoard.instance.gameData.playerWhite.RemoveDeckCards();
-        GameBoard.instance.gameData.playerBlack.RemoveHandCards();
         GameBoard.instance.gameData.playerBlack.RemoveDeckCards();
+        GameBoard.instance.gameData.playerWhite.RemoveDeckCards();
 
         if (surtrComponent.InfusedPiece.pieceColor == GameBoard.PlayerColor.Black)
         {
-            GameBoard.instance.gameData.playerBlack.TryAddCardInHand(GetComponent<Card>());
+            GameBoard.instance.gameData.playerWhite.RemoveHandCards();
+            foreach (var card in GameBoard.instance.gameData.playerBlack.hand.ToList())
+            {
+                if (card != GetComponent<Surtr>())
+                {
+                    GameBoard.instance.gameData.playerBlack.hand.Remove(card);
+                    card.Destroy();
+                }
+            }
         }
         else
         {
+            GameBoard.instance.gameData.playerBlack.RemoveHandCards();
             GameBoard.instance.gameData.playerWhite.TryAddCardInHand(GetComponent<Card>());
+            foreach (var card in GameBoard.instance.gameData.playerWhite.hand.ToList())
+            {
+                if (card != GetComponent<Surtr>())
+                {
+                    GameBoard.instance.gameData.playerBlack.hand.Remove(card);
+                    card.Destroy();
+                }
+            }
         }
     }
 }

--- a/Assets/Script/Game/GameBoard.cs
+++ b/Assets/Script/Game/GameBoard.cs
@@ -162,6 +162,8 @@ public class GameBoard : MonoBehaviour
 
     IEnumerator KillPieceAnimationC(ChessPiece targetPiece)
     {
+        gameData.pieceObjects.Remove(targetPiece);
+        
         yield return new WaitForSeconds(1.5f);
         if (targetPiece.pieceColor == PlayerColor.White)
         {
@@ -176,8 +178,6 @@ public class GameBoard : MonoBehaviour
 
         targetPiece.effectIcon.RemoveIcon();
         targetPiece.DestroyMoveRestrictionIcon();
-        gameData.pieceObjects.Remove(targetPiece);
-
         targetPiece.transform.position = chessBoard.GetPositionUsingCoordinate(targetPiece.coordinate);
     }
 

--- a/Assets/Script/Game/UI/DeckHandController.cs
+++ b/Assets/Script/Game/UI/DeckHandController.cs
@@ -127,15 +127,20 @@ public class DeckHandController : MonoBehaviour
     {
         yield return objCard.transform.DOLocalMoveX(anchor_x + CARD_DISTANCE_IN_HAND * handIndex, 0.3f).WaitForCompletion();
         yield return objCard.transform.DOLocalMoveY(0, 0.7f).WaitForCompletion();
-        objCard.transform.localPosition = new Vector3(anchor_x + CARD_DISTANCE_IN_HAND * handIndex, 0, -0.1f * handIndex); //UI에 맞게 좌표수정
-        if (objCard.cost <= GameBoard.instance.gameData.myPlayerData.soulEssence)
+        if (objCard != null)
         {
-            objCard.GetComponent<CardObject>().canUseEffectRenderer.material.SetFloat("_Alpha", 1f);
+            objCard.transform.localPosition = new Vector3(anchor_x + CARD_DISTANCE_IN_HAND * handIndex, 0, -0.1f * handIndex); //UI에 맞게 좌표수정
+            if (objCard.cost <= GameBoard.instance.gameData.myPlayerData.soulEssence)
+            {
+                objCard.GetComponent<CardObject>().canUseEffectRenderer.material.SetFloat("_Alpha", 1f);
+            }
+            else
+            {
+                objCard.GetComponent<CardObject>().canUseEffectRenderer.material.SetFloat("_Alpha", 0f);
+            }
         }
         else
-        {
-            objCard.GetComponent<CardObject>().canUseEffectRenderer.material.SetFloat("_Alpha", 0f);
-        }
+            Debug.Log("Hand Null");
     }
 
     public void UpdateOpponentHandPosition()
@@ -168,7 +173,12 @@ public class DeckHandController : MonoBehaviour
     {
         yield return objCard.transform.DOLocalMoveX(anchor_x - CARD_DISTANCE_IN_HAND * handIndex, 0.3f).WaitForCompletion();
         yield return objCard.transform.DOLocalMoveY(0, 0.8f).WaitForCompletion();
-        objCard.transform.localPosition = new Vector3(anchor_x - CARD_DISTANCE_IN_HAND * handIndex, 0, -0.1f * handIndex); //UI에 맞게 좌표수정
+        if (objCard != null)
+        {
+            objCard.transform.localPosition = new Vector3(anchor_x - CARD_DISTANCE_IN_HAND * handIndex, 0, -0.1f * handIndex); //UI에 맞게 좌표수정
+        }
+        else
+            Debug.Log("Hand Null");
     }
 
 

--- a/Assets/Sprites/Legacy/GameObjects/CardAccessory/Norse/Frigg_accessory.png.meta
+++ b/Assets/Sprites/Legacy/GameObjects/CardAccessory/Norse/Frigg_accessory.png.meta
@@ -48,7 +48,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 512
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/Legacy/GameObjects/CardAccessory/Norse/Surtr_accessory.png.meta
+++ b/Assets/Sprites/Legacy/GameObjects/CardAccessory/Norse/Surtr_accessory.png.meta
@@ -48,7 +48,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 512
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1


### PR DESCRIPTION
pieceObject의 제거가 느리게 일어나던 오류를 수정했습니다.
수르트 카드 제거 방식을 변경하였습니다.
티타노마키아 카드를 재수정하였습니다.

크기 조절이 되지 않았던 악세서리의 크기를 조절했습니다.

TODO:
현재 카드를 다 사용했을 때 사라졌어야할 카드가
반영이 느리게 되어서 위치가 조정되다가 사라지면서 null reference 문제를 일으켜 임시로 예외처리해 둔 상태라 이게 근본적으로 해결이 될 수 있는 문제인지 확인이 필요합니다.