### PR TITLE
카드 손패 관련 수정

### DIFF
--- a/Assets/Materials/CardBurnMaterial.mat
+++ b/Assets/Materials/CardBurnMaterial.mat
@@ -7,14 +7,12 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: CardPrefabMaterial
+  m_Name: CardBurnMaterial
   m_Shader: {fileID: 4800000, guid: a36b7719ff0465b42ab1407d67672c5f, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
-  - DISTORT_ON
-  - OUTBASE_ON
-  - RECTSIZE_ON
+  - FADE_ON
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -76,7 +74,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
-    - _Alpha: 0
+    - _Alpha: 1
     - _AlphaCutoffValue: 0.25
     - _AlphaOutlineBlend: 1
     - _AlphaOutlineGlow: 5
@@ -106,7 +104,7 @@ Material:
     - _ColorSwapRedLuminosity: 0.5
     - _Contrast: 1
     - _CullingOption: 0
-    - _DistortAmount: 0.08
+    - _DistortAmount: 0
     - _DistortTexXSpeed: 1
     - _DistortTexYSpeed: 1
     - _EditorDrawers: 6
@@ -166,7 +164,7 @@ Material:
     - _OffsetUvY: 0
     - _OnlyInnerOutline: 0
     - _OnlyOutline: 0
-    - _OutlineAlpha: 1
+    - _OutlineAlpha: 0
     - _OutlineDistortAmount: 0.13
     - _OutlineDistortTexXSpeed: 0
     - _OutlineDistortTexYSpeed: -2

--- a/Assets/Materials/CardBurnMaterial.mat.meta
+++ b/Assets/Materials/CardBurnMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c6a7eb8b34b6ad45917c0e4032446af
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Game/Cards/_CardPrefab.prefab
+++ b/Assets/Prefabs/Game/Cards/_CardPrefab.prefab
@@ -145,7 +145,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: 3c6a7eb8b34b6ad45917c0e4032446af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -248,12 +248,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cardNameText: {fileID: 6790022253308629777}
   costText: {fileID: 2890987037114931955}
-  spriteRenderer: {fileID: 6665048331891296882}
+  illustration: {fileID: 6665048331891296882}
   descriptionText: {fileID: 2076236272955096686}
   backSpriteRenderer: {fileID: 3018793139727406675}
   canUseEffectRenderer: {fileID: 5823763045071059939}
   ADCircle: {fileID: 0}
   HPCircle: {fileID: 0}
+  typeImage: {fileID: 0}
 --- !u!1 &2307050580273995933
 GameObject:
   m_ObjectHideFlags: 0
@@ -561,7 +562,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: 3c6a7eb8b34b6ad45917c0e4032446af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefabs/Game/Cards/_SoulCard.prefab
+++ b/Assets/Prefabs/Game/Cards/_SoulCard.prefab
@@ -972,6 +972,10 @@ PrefabInstance:
       propertyPath: HPCircle
       value: 
       objectReference: {fileID: 4400087011069823492}
+    - target: {fileID: 699316848449856855, guid: 881fdce7cd923a0478a4313009ec0886, type: 3}
+      propertyPath: typeImage
+      value: 
+      objectReference: {fileID: 2517401516355074278}
     - target: {fileID: 1276941704583445816, guid: 881fdce7cd923a0478a4313009ec0886, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/Prefabs/Game/Cards/_SpellCard.prefab
+++ b/Assets/Prefabs/Game/Cards/_SpellCard.prefab
@@ -348,6 +348,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 699316848449856855, guid: 881fdce7cd923a0478a4313009ec0886, type: 3}
+      propertyPath: typeImage
+      value: 
+      objectReference: {fileID: 8157012540587055986}
     - target: {fileID: 1276941704583445816, guid: 881fdce7cd923a0478a4313009ec0886, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.20000002

--- a/Assets/Script/Game/Card/Card.cs
+++ b/Assets/Script/Game/Card/Card.cs
@@ -55,7 +55,7 @@ public abstract class Card : TargetableObject, IPointerEnterHandler, IPointerExi
 
         cardObject.cardNameText.text = cardName;
         cardObject.costText.text = cost.ToString();
-        cardObject.spriteRenderer.sprite = illustration;
+        cardObject.illustration.sprite = illustration;
         cardObject.descriptionText.text = description;
         cardObject.backSpriteRenderer.sprite = back;
     }

--- a/Assets/Script/Game/Card/CardObject.cs
+++ b/Assets/Script/Game/Card/CardObject.cs
@@ -7,10 +7,11 @@ public class CardObject : MonoBehaviour
 {
     public TextMeshPro cardNameText;
     public TextMeshPro costText;
-    public SpriteRenderer spriteRenderer;
+    public SpriteRenderer illustration;
     public TextMeshPro descriptionText;
     public SpriteRenderer backSpriteRenderer;
     public Renderer canUseEffectRenderer;
     public GameObject ADCircle;
     public GameObject HPCircle;
+    public GameObject typeImage;
 }

--- a/Assets/Script/Game/PlayerData.cs
+++ b/Assets/Script/Game/PlayerData.cs
@@ -63,8 +63,12 @@ public class PlayerData
 
     public IEnumerator DrawCardWithAnimation()
     {
+        GameObject blocker = GameBoard.instance.chessBoard.blocker;
+        blocker.SetActive(true);
+
         if (deck.Count <= 0)
         {
+            blocker.SetActive(false);
             UpdateHandPosition();
             yield break;
         }
@@ -93,7 +97,36 @@ public class PlayerData
             if (IsHandFull())
             {
                 UpdateHandPosition();
+                CardObject cardobj = card.GetComponent<CardObject>();
+                GameObject costCircle = cardobj.costText.transform.parent.gameObject;
+                Material frameMaterial = card.GetComponent<Renderer>().material;
+                Material illustMaterial = cardobj.illustration.GetComponent<Renderer>().material;
+                    
+                if (card is SoulCard)
+                {
+                    cardobj.ADCircle.SetActive(false);
+                    cardobj.HPCircle.SetActive(false);
+                }
+                cardobj.canUseEffectRenderer.gameObject.SetActive(false);
+                cardobj.backSpriteRenderer.gameObject.SetActive(false);
+                cardobj.typeImage.SetActive(false);
+                costCircle.SetActive(false);
+
+                yield return DOVirtual.Float(-0.1f, 1f, 0.5f, (value) => {
+                    frameMaterial.SetFloat("_FadeAmount", value);
+                    illustMaterial.SetFloat("_FadeAmount", value);
+                }).WaitForCompletion();
+
+                yield return DOVirtual.Float(1f, 0f, 0.8f, (value) => {
+                    cardobj.cardNameText.alpha = value;
+                    cardobj.descriptionText.alpha = value;
+                    
+                    float lerpedValue = Mathf.Lerp(0.5f, 1f, value);
+                    frameMaterial.SetFloat("_FadeBurnWidth", lerpedValue);
+                    illustMaterial.SetFloat("_FadeBurnWidth", lerpedValue);
+                }).SetEase(Ease.Linear).WaitForCompletion();
                 DestroyCard(card);
+                blocker.SetActive(false);
             }
             else
             {
@@ -108,6 +141,7 @@ public class PlayerData
                     card.transform.position = new Vector3(-5.85f, 7f, 0);
                 }
                 GetCard(card);
+                blocker.SetActive(false);
             }
         }
     }

--- a/Assets/Script/Game/UI/DeckHandController.cs
+++ b/Assets/Script/Game/UI/DeckHandController.cs
@@ -125,6 +125,8 @@ public class DeckHandController : MonoBehaviour
     }
     IEnumerator UpdateMyHandPositionAnimation(Card objCard, float anchor_x, int handIndex)
     {
+        bool highlightSignal = false;
+
         if (objCard == null) yield break;
         yield return objCard.transform.DOLocalMoveX(anchor_x + CARD_DISTANCE_IN_HAND * handIndex, 0.3f).WaitForCompletion();
         if (objCard == null) yield break;
@@ -133,6 +135,16 @@ public class DeckHandController : MonoBehaviour
         {
             objCard.transform.localPosition = new Vector3(anchor_x + CARD_DISTANCE_IN_HAND * handIndex, 0, -0.1f * handIndex); //UI에 맞게 좌표수정
             if (objCard.cost <= GameBoard.instance.gameData.myPlayerData.soulEssence)
+            {
+                highlightSignal = true;
+
+                if (objCard.EffectOnCardUsed is TargetingEffect effect && !effect.isAvailable(GameBoard.instance.myController.playerColor))
+                {
+                    highlightSignal = false;
+                }
+            }
+
+            if (objCard != null && highlightSignal == true)
             {
                 objCard.GetComponent<CardObject>().canUseEffectRenderer.material.SetFloat("_Alpha", 1f);
             }


### PR DESCRIPTION
코스트 상으로는 사용 가능한데 사용 조건이 맞지 않아 사용할 수 없는 카드에 초록색 테두리를 그리지 않도록 변경
손패가 가득 차 없어지는 카드에 불타는 효과 쉐이더로 추가